### PR TITLE
fix: resolve Emby item queries by media source ID

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -23,7 +23,7 @@
 - LUX-023：已完成根路径/`/emby` 前缀的 System/Ping 本地协议 shape 测试；`GET/POST /System/Ping` 按 Emby OpenAPI 兼容为无需认证的空 200，并完成 VidHub/SenPlayer 真实登录前置探针。
 - LUX-024：已完成 Users/Public、AuthenticateByName、Sessions/Logout 的本地协议 shape 和 token 脱敏测试；VidHub 真实登录通过；SenPlayer 认证响应解析失败的历史缺口已补充更完整的 `User`/`SessionInfo` shape，并补齐认证后 `GET /Users/:userId` 用户详情路由；P0 真实 UI 复测已通过。
 - SenPlayer 列表兼容修复：当请求的 `Fields` 未包含 `MediaSources` 或 `MediaStreams` 时，Emby 列表响应不再携带这些字段；详情和 `PlaybackInfo` 仍返回完整媒体源。自动化回归已覆盖，真实客户端需要清理缓存或重新进入库后复测。
-- Emby `GET /Items` 现在按逗号分隔的 `Ids` 严格过滤条目；未知 ItemId、MediaSourceId 或不存在的 UUID 返回空 `Items` 和 `TotalRecordCount: 0`。自动化 catalog 回归已覆盖，修复了 Redia 将所有影片解析为媒体库第一条记录的问题。
+- Emby `GET /Items` 现在按逗号分隔的 `Ids` 严格过滤条目，并兼容 Redia 将 `MediaSourceId` 作为 `Ids` 查询的行为：命中媒体源时返回其所属条目，完全未知的 ID 仍返回空 `Items` 和 `TotalRecordCount: 0`。自动化 catalog 回归已覆盖，既避免把未知 ID 解析为媒体库第一条记录，也允许 Redia 获取正确的 STRM 路径。
 - `cargo` 验证是在本机 `arm64` 上完成，不代表目标 x86_64 飞牛 NAS 性能或客户端兼容性。
 - Web 的“已实现”仅表示代码路径和服务端静态集成已完成；当前 Chrome smoke 覆盖登录、筛选、播放、收藏、账户会话和管理流程，不等同于所有浏览器/编码格式兼容。
 - LUX-121 兼容补齐：Emby `Views` 返回媒体库类型、`ChildCount` 和标准 `ImageTags.Primary`；条目详情同时返回本地徽标的 `ImageTags.Logo`，并通过 `/Items/{itemId}/Images/Logo` 提供标准图片读取；媒体库封面支持 `/Items/{libraryId}/Images/Primary` 及带索引、HEAD、ETag 和 ACL。尚待 VidHub UI 重新实测确认。

--- a/docs/LUX-DEVELOPMENT.md
+++ b/docs/LUX-DEVELOPMENT.md
@@ -1315,6 +1315,7 @@ COMPATIBILITY.md 是唯一兼容性事实来源。不能因为实现了官方 Sw
 ### 15.4 必须正确的 Emby 查询语义
 
 - UserId、ParentId、Ids。
+- `GET /Items` 的 `Ids` 严格匹配条目 ID；为兼容使用媒体源 ID 查询路径的 Emby 代理，也可匹配 `MediaSourceId` 并返回其所属条目。完全未知的 ID 返回空列表，不得回退为未过滤目录页。
 - IncludeItemTypes、ExcludeItemTypes。
 - Recursive。
 - StartIndex、Limit。

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1529,6 +1529,7 @@ fn catalog_filter_from_values(
     CatalogFilter {
         item_types,
         item_ids: None,
+        media_source_ids: None,
         years,
         is_played,
         is_favorite,
@@ -1556,7 +1557,7 @@ fn catalog_filter_from_emby(query: &EmbyItemsQuery) -> CatalogFilter {
         query.sort_by.as_deref(),
         query.sort_order.as_deref(),
     );
-    filter.item_ids = query.ids.as_deref().map(|values| {
+    let ids = query.ids.as_deref().map(|values| {
         values
             .split(',')
             .map(str::trim)
@@ -1564,6 +1565,8 @@ fn catalog_filter_from_emby(query: &EmbyItemsQuery) -> CatalogFilter {
             .map(str::to_owned)
             .collect()
     });
+    filter.item_ids = ids.clone();
+    filter.media_source_ids = ids;
     filter
 }
 

--- a/src/application/catalog.rs
+++ b/src/application/catalog.rs
@@ -18,6 +18,7 @@ use crate::{
 pub struct CatalogFilter {
     pub item_types: Vec<String>,
     pub item_ids: Option<Vec<String>>,
+    pub media_source_ids: Option<Vec<String>>,
     pub years: Vec<i64>,
     pub is_played: Option<bool>,
     pub is_favorite: Option<bool>,
@@ -100,6 +101,7 @@ impl CatalogService {
             user_id: &user_id,
             item_types: &filter.item_types,
             item_ids: filter.item_ids.as_deref(),
+            media_source_ids: filter.media_source_ids.as_deref(),
             years: &filter.years,
             is_played: filter.is_played,
             is_favorite: filter.is_favorite,
@@ -138,6 +140,7 @@ impl CatalogService {
             user_id: &user_id,
             item_types: &filter.item_types,
             item_ids: filter.item_ids.as_deref(),
+            media_source_ids: filter.media_source_ids.as_deref(),
             years: &filter.years,
             is_played: filter.is_played,
             is_favorite: filter.is_favorite,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -5915,15 +5915,7 @@ impl Database {
         if filter.library_ids.is_empty() {
             return Ok((Vec::new(), 0));
         }
-        let (where_clause, filter_binds) = catalog_filter_where_clause(
-            filter.library_ids,
-            filter.user_id,
-            filter.item_types,
-            filter.item_ids,
-            filter.years,
-            filter.is_played,
-            filter.is_favorite,
-        );
+        let (where_clause, filter_binds) = catalog_filter_where_clause(filter);
         let count_query = format!(
             "SELECT COUNT(*) FROM media_items mi
              JOIN libraries l ON l.id = mi.library_id AND l.is_enabled = 1
@@ -8756,14 +8748,16 @@ fn stored_item_image(row: sqlx::any::AnyRow) -> StoredItemImage {
 }
 
 fn catalog_filter_where_clause<'a>(
-    library_ids: &'a [String],
-    user_id: &'a str,
-    item_types: &'a [String],
-    item_ids: Option<&'a [String]>,
-    years: &'a [i64],
-    is_played: Option<bool>,
-    is_favorite: Option<bool>,
+    filter: &CatalogFilterQuery<'a>,
 ) -> (String, Vec<CatalogBind<'a>>) {
+    let library_ids = filter.library_ids;
+    let user_id = filter.user_id;
+    let item_types = filter.item_types;
+    let item_ids = filter.item_ids;
+    let media_source_ids = filter.media_source_ids;
+    let years = filter.years;
+    let is_played = filter.is_played;
+    let is_favorite = filter.is_favorite;
     let mut where_clause = format!(
         "WHERE mi.removed_at IS NULL
          AND mi.library_id IN ({})",
@@ -8776,22 +8770,44 @@ fn catalog_filter_where_clause<'a>(
         .iter()
         .map(|library_id| CatalogBind::Text(library_id.as_str()))
         .collect::<Vec<_>>();
-    match item_ids {
-        Some([]) => where_clause.push_str(" AND 1 = 0"),
-        Some(item_ids) => {
-            where_clause.push_str(&format!(
-                " AND mi.id IN ({})",
-                std::iter::repeat_n("?", item_ids.len())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ));
-            binds.extend(
-                item_ids
-                    .iter()
-                    .map(|item_id| CatalogBind::Text(item_id.as_str())),
-            );
+    let mut id_predicates = Vec::new();
+    if let Some(item_ids) = item_ids
+        && !item_ids.is_empty()
+    {
+        id_predicates.push(format!(
+            "mi.id IN ({})",
+            std::iter::repeat_n("?", item_ids.len())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+        binds.extend(
+            item_ids
+                .iter()
+                .map(|item_id| CatalogBind::Text(item_id.as_str())),
+        );
+    }
+    if let Some(media_source_ids) = media_source_ids
+        && !media_source_ids.is_empty()
+    {
+        id_predicates.push(format!(
+            "EXISTS (SELECT 1 FROM media_sources ms_filter
+                     WHERE ms_filter.item_id = mi.id AND ms_filter.id IN ({}))",
+            std::iter::repeat_n("?", media_source_ids.len())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+        binds.extend(
+            media_source_ids
+                .iter()
+                .map(|media_source_id| CatalogBind::Text(media_source_id.as_str())),
+        );
+    }
+    if item_ids.is_some() || media_source_ids.is_some() {
+        if id_predicates.is_empty() {
+            where_clause.push_str(" AND 1 = 0");
+        } else {
+            where_clause.push_str(&format!(" AND ({})", id_predicates.join(" OR ")));
         }
-        None => {}
     }
     if !item_types.is_empty() {
         where_clause.push_str(&format!(
@@ -8907,6 +8923,7 @@ pub(crate) struct CatalogFilterQuery<'a> {
     pub(crate) user_id: &'a str,
     pub(crate) item_types: &'a [String],
     pub(crate) item_ids: Option<&'a [String]>,
+    pub(crate) media_source_ids: Option<&'a [String]>,
     pub(crate) years: &'a [i64],
     pub(crate) is_played: Option<bool>,
     pub(crate) is_favorite: Option<bool>,

--- a/tests/catalog.rs
+++ b/tests/catalog.rs
@@ -330,25 +330,47 @@ async fn lux_and_emby_catalogs_list_page_and_show_movie_details()
         Some(2)
     );
 
-    for id in [
-        alpha_source_id,
-        "00000000-0000-0000-0000-000000000000".to_owned(),
-    ] {
-        let filtered_by_unknown_id = client
-            .get(format!("{base_url}/Items?Ids={id}&Limit=1"))
-            .header("X-Emby-Token", &admin_token)
-            .send()
-            .await?;
-        assert_eq!(filtered_by_unknown_id.status(), reqwest::StatusCode::OK);
-        let filtered_by_unknown_id_body: Value = filtered_by_unknown_id.json().await?;
-        assert_eq!(filtered_by_unknown_id_body["TotalRecordCount"], 0);
-        assert_eq!(
-            filtered_by_unknown_id_body["Items"]
-                .as_array()
-                .map(Vec::len),
-            Some(0)
-        );
-    }
+    let filtered_by_media_source_id = client
+        .get(format!(
+            "{base_url}/Items?Ids={alpha_source_id}&Fields=Path,MediaSources&Limit=1"
+        ))
+        .header("X-Emby-Token", &admin_token)
+        .send()
+        .await?;
+    assert_eq!(
+        filtered_by_media_source_id.status(),
+        reqwest::StatusCode::OK
+    );
+    let filtered_by_media_source_id_body: Value = filtered_by_media_source_id.json().await?;
+    assert_eq!(filtered_by_media_source_id_body["TotalRecordCount"], 1);
+    assert_eq!(
+        filtered_by_media_source_id_body["Items"]
+            .as_array()
+            .map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(filtered_by_media_source_id_body["Items"][0]["Id"], item_id);
+    assert_eq!(
+        filtered_by_media_source_id_body["Items"][0]["MediaSources"][0]["Id"],
+        alpha_source_id
+    );
+
+    let filtered_by_unknown_id = client
+        .get(format!(
+            "{base_url}/Items?Ids=00000000-0000-0000-0000-000000000000&Limit=1"
+        ))
+        .header("X-Emby-Token", &admin_token)
+        .send()
+        .await?;
+    assert_eq!(filtered_by_unknown_id.status(), reqwest::StatusCode::OK);
+    let filtered_by_unknown_id_body: Value = filtered_by_unknown_id.json().await?;
+    assert_eq!(filtered_by_unknown_id_body["TotalRecordCount"], 0);
+    assert_eq!(
+        filtered_by_unknown_id_body["Items"]
+            .as_array()
+            .map(Vec::len),
+        Some(0)
+    );
 
     let emby_compact_page = client
         .get(format!(


### PR DESCRIPTION
## Summary

- keep `/Items?Ids=<ItemId>` behavior unchanged
- resolve known `MediaSourceId` values to their owning media item for Redia compatibility
- keep unknown IDs returning an empty result
- use a bounded SQL `EXISTS` lookup against `media_sources`, without scanning the full library

## Context

Redia requests `/Items?Ids=<MediaSourceId>&Fields=Path,MediaSources&Limit=1`. Lux 0.1.4 correctly stopped unknown IDs from falling back to the first library item, but a media-source ID was then treated as unknown and playback failed. This compatibility mapping preserves strict unknown-ID behavior while supporting that established client request shape.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --locked --test catalog`
- `cargo build --locked`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`

The relevant catalog regression passes consistently. A full `cargo test --all-targets` run also encountered unrelated environment-sensitive failures in `admin_health` and existing SQLx driver initialization.