### PR TITLE
fix: make metadata refresh jobs resilient

### DIFF
--- a/src/application/reidentify.rs
+++ b/src/application/reidentify.rs
@@ -293,7 +293,15 @@ impl MetadataReidentifyService {
                 service.process_item(&job_id, &item_id, mode).await;
             });
         }
-        while workers.join_next().await.is_some() {
+        while let Some(worker_result) = workers.join_next().await {
+            if let Err(error) = worker_result {
+                tracing::error!(
+                    job_id,
+                    worker_cancelled = error.is_cancelled(),
+                    worker_panicked = error.is_panic(),
+                    "metadata refresh worker stopped before recording its result"
+                );
+            }
             while workers.len() < METADATA_MATCH_CONCURRENCY {
                 if self
                     .database
@@ -322,6 +330,25 @@ impl MetadataReidentifyService {
                 });
             }
         }
+        let reconciliation_failed = match self
+            .database
+            .fail_running_metadata_reidentify_items(job_id, "WORKER_FAILED")
+            .await
+        {
+            Ok(0) => false,
+            Ok(count) => {
+                tracing::error!(
+                    job_id,
+                    item_count = count,
+                    "metadata refresh reconciled items left running by workers"
+                );
+                false
+            }
+            Err(_) => {
+                tracing::error!(job_id, "metadata refresh could not reconcile running items");
+                true
+            }
+        };
         let status = if self
             .database
             .metadata_reidentify_job_cancel_requested(job_id)
@@ -329,6 +356,8 @@ impl MetadataReidentifyService {
             .unwrap_or(true)
         {
             "CANCELLED"
+        } else if reconciliation_failed {
+            "FAILED"
         } else {
             match self
                 .database
@@ -340,14 +369,18 @@ impl MetadataReidentifyService {
                 Err(_) => "FAILED",
             }
         };
-        let _ = self
+        if self
             .database
             .finish_metadata_reidentify_job(
                 job_id,
                 status,
                 (status == "FAILED").then_some("ITEM_FAILED"),
             )
-            .await;
+            .await
+            .is_err()
+        {
+            tracing::error!(job_id, "metadata refresh job status could not be recorded");
+        }
         self.admin_events.publish(AdminEventScope::Jobs);
     }
 
@@ -408,12 +441,39 @@ impl MetadataReidentifyService {
                 self.admin_events.publish(AdminEventScope::Jobs);
                 self.admin_events.publish(AdminEventScope::Metadata);
             }
+            Err(MetadataReidentifyError::LowConfidence) => {
+                let code = MetadataReidentifyError::LowConfidence.code();
+                if self
+                    .database
+                    .finish_metadata_reidentify_item(job_id, item_id, "COMPLETED", 0, Some(code))
+                    .await
+                    .is_err()
+                {
+                    tracing::error!(
+                        job_id,
+                        item_id,
+                        error_code = code,
+                        "metadata refresh item result could not be recorded"
+                    );
+                }
+                self.admin_events.publish(AdminEventScope::Jobs);
+                self.admin_events.publish(AdminEventScope::Metadata);
+            }
             Err(error) => {
                 let code = error.code();
-                let _ = self
+                if self
                     .database
                     .finish_metadata_reidentify_item(job_id, item_id, "FAILED", 0, Some(code))
-                    .await;
+                    .await
+                    .is_err()
+                {
+                    tracing::error!(
+                        job_id,
+                        item_id,
+                        error_code = code,
+                        "metadata refresh item result could not be recorded"
+                    );
+                }
                 self.admin_events.publish(AdminEventScope::Jobs);
                 self.admin_events.publish(AdminEventScope::Metadata);
             }
@@ -607,8 +667,15 @@ impl MetadataReidentifyError {
             Self::JobNotCancelable => "JOB_NOT_CANCELABLE",
             Self::Candidate(MetadataCandidateError::Tmdb(_)) => "TMDB_UNAVAILABLE",
             Self::Candidate(MetadataCandidateError::InvalidSearch) => "INVALID_SEARCH",
-            Self::Candidate(_) => "CANDIDATE_ERROR",
+            Self::Candidate(MetadataCandidateError::ItemNotFound) => "ITEM_NOT_FOUND",
+            Self::Candidate(MetadataCandidateError::InvalidCandidateJson(_)) => "CANDIDATE_ERROR",
+            Self::Candidate(MetadataCandidateError::Scraper(_)) => "SCRAPER_UNAVAILABLE",
+            Self::Candidate(MetadataCandidateError::Storage(_)) => "STORAGE_ERROR",
             Self::Scraper(_) => "SCRAPER_UNAVAILABLE",
+            Self::Selection(MetadataSelectionError::Nfo(_)) => "METADATA_NFO_WRITE_FAILED",
+            Self::Selection(MetadataSelectionError::Image(_)) => "METADATA_IMAGE_WRITE_FAILED",
+            Self::Selection(MetadataSelectionError::People(_)) => "METADATA_PEOPLE_WRITE_FAILED",
+            Self::Selection(MetadataSelectionError::Storage(_)) => "METADATA_STORAGE_FAILED",
             Self::Selection(_) => "METADATA_WRITE_FAILED",
             Self::SelectionUnavailable => "METADATA_WRITE_UNAVAILABLE",
             Self::LowConfidence => "LOW_CONFIDENCE",

--- a/src/bin/lux-plugin-tmdb.rs
+++ b/src/bin/lux-plugin-tmdb.rs
@@ -297,6 +297,7 @@ async fn search_movies(
     let client = client()
         .await
         .map_err(|error| luxd::application::tmdb::TmdbError::Transport(error.message))?;
+    let mut last_response = None;
     for search_year in search_years(year) {
         for candidate in title_candidates(query) {
             let response = client
@@ -305,9 +306,10 @@ async fn search_movies(
             if !response.results.is_empty() {
                 return Ok(response);
             }
+            last_response = Some(response);
         }
     }
-    Err(luxd::application::tmdb::TmdbError::NotFound)
+    completed_search(last_response)
 }
 
 async fn search_tv(
@@ -318,15 +320,21 @@ async fn search_tv(
     let client = client()
         .await
         .map_err(|error| luxd::application::tmdb::TmdbError::Transport(error.message))?;
+    let mut last_response = None;
     for search_year in search_years(year) {
         for candidate in title_candidates(query) {
             let response = client.search_tv(&candidate, search_year, language).await?;
             if !response.results.is_empty() {
                 return Ok(response);
             }
+            last_response = Some(response);
         }
     }
-    Err(luxd::application::tmdb::TmdbError::NotFound)
+    completed_search(last_response)
+}
+
+fn completed_search<T>(last_response: Option<T>) -> Result<T, luxd::application::tmdb::TmdbError> {
+    last_response.ok_or(luxd::application::tmdb::TmdbError::NotFound)
 }
 
 fn search_years(year: Option<i32>) -> Vec<Option<i32>> {
@@ -1049,5 +1057,24 @@ fn tmdb_error(error: luxd::application::tmdb::TmdbError) -> PluginRpcError {
     PluginRpcError {
         code: "PLUGIN_PROVIDER_ERROR".to_owned(),
         message: error.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_search_response_is_not_reported_as_a_provider_error() {
+        let response = TmdbMovieSearchResponse {
+            page: 1,
+            total_pages: 0,
+            total_results: 0,
+            results: Vec::new(),
+        };
+
+        let completed = completed_search(Some(response)).expect("empty response");
+
+        assert!(completed.results.is_empty());
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3245,6 +3245,59 @@ impl Database {
             })
     }
 
+    pub(crate) async fn fail_running_metadata_reidentify_items(
+        &self,
+        job_id: &str,
+        error: &str,
+    ) -> Result<i64, StorageError> {
+        let mut transaction = self
+            .pool
+            .begin()
+            .await
+            .map_err(|source| StorageError::Sqlx {
+                path: self.path.clone(),
+                source,
+            })?;
+        let result = self
+            .query(
+                "UPDATE metadata_reidentify_job_items
+                 SET status = 'FAILED', candidate_count = 0, error = ?, updated_at = unixepoch()
+                 WHERE job_id = ? AND status = 'RUNNING'",
+            )
+            .bind(error)
+            .bind(job_id)
+            .execute(&mut *transaction)
+            .await
+            .map_err(|source| StorageError::Sqlx {
+                path: self.path.clone(),
+                source,
+            })?;
+        let affected = i64::try_from(result.rows_affected()).unwrap_or(i64::MAX);
+        if affected > 0 {
+            self.query(
+                "UPDATE metadata_reidentify_jobs
+                 SET processed_count = processed_count + ?, updated_at = unixepoch()
+                 WHERE id = ?",
+            )
+            .bind(affected)
+            .bind(job_id)
+            .execute(&mut *transaction)
+            .await
+            .map_err(|source| StorageError::Sqlx {
+                path: self.path.clone(),
+                source,
+            })?;
+        }
+        transaction
+            .commit()
+            .await
+            .map_err(|source| StorageError::Sqlx {
+                path: self.path.clone(),
+                source,
+            })?;
+        Ok(affected)
+    }
+
     pub(crate) async fn finish_metadata_reidentify_job(
         &self,
         job_id: &str,
@@ -9638,6 +9691,95 @@ mod tests {
             database.next_metadata_reidentify_item("job").await.unwrap(),
             Some("season".to_owned())
         );
+        database.close().await;
+    }
+
+    #[tokio::test]
+    async fn metadata_jobs_reconcile_items_left_running_by_workers() {
+        sqlx::any::install_default_drivers();
+        let pool = AnyPoolOptions::new()
+            .max_connections(1)
+            .connect_with(
+                AnyConnectOptions::from_str("sqlite://?mode=memory")
+                    .expect("in-memory SQLite options"),
+            )
+            .await
+            .expect("in-memory SQLite connection");
+        sqlx::query(
+            "CREATE TABLE metadata_reidentify_jobs (
+                id TEXT PRIMARY KEY,
+                processed_count INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create metadata jobs table");
+        sqlx::query(
+            "CREATE TABLE metadata_reidentify_job_items (
+                job_id TEXT NOT NULL,
+                item_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                candidate_count INTEGER NOT NULL,
+                error TEXT,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (job_id, item_id)
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create metadata job items table");
+        sqlx::query(
+            "INSERT INTO metadata_reidentify_jobs (id, processed_count, updated_at)
+             VALUES ('job', 0, unixepoch())",
+        )
+        .execute(&pool)
+        .await
+        .expect("insert metadata job");
+        for (item_id, status) in [
+            ("running-1", "RUNNING"),
+            ("running-2", "RUNNING"),
+            ("done", "COMPLETED"),
+        ] {
+            sqlx::query(
+                "INSERT INTO metadata_reidentify_job_items (
+                    job_id, item_id, status, candidate_count, error, updated_at
+                 ) VALUES ('job', ?, ?, 0, NULL, unixepoch())",
+            )
+            .bind(item_id)
+            .bind(status)
+            .execute(&pool)
+            .await
+            .expect("insert metadata job item");
+        }
+        let database = Database {
+            pool,
+            path: PathBuf::from("metadata-reconcile-test.db"),
+            server_id: "test".to_owned(),
+            backend: DatabaseBackend::Sqlite,
+        };
+
+        let reconciled = database
+            .fail_running_metadata_reidentify_items("job", "WORKER_FAILED")
+            .await
+            .expect("reconcile running items");
+
+        assert_eq!(reconciled, 2);
+        let failed_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM metadata_reidentify_job_items
+             WHERE job_id = 'job' AND status = 'FAILED' AND error = 'WORKER_FAILED'",
+        )
+        .fetch_one(database.pool())
+        .await
+        .expect("failed item count");
+        assert_eq!(failed_count, 2);
+        let processed_count: i64 = sqlx::query_scalar(
+            "SELECT processed_count FROM metadata_reidentify_jobs WHERE id = 'job'",
+        )
+        .fetch_one(database.pool())
+        .await
+        .expect("processed count");
+        assert_eq!(processed_count, 2);
         database.close().await;
     }
 

--- a/tests/reidentify.rs
+++ b/tests/reidentify.rs
@@ -10,6 +10,7 @@ use axum::{Json, Router, extract::State as AxumState, routing::any};
 use luxd::{
     api::{AppState, app_with_state},
     application::{
+        candidates::MetadataSelectionService,
         images::ImageWriteService,
         libraries::LibraryService,
         metadata::MetadataEnricher,
@@ -148,6 +149,14 @@ async fn admin_can_start_and_poll_metadata_reidentify() -> Result<(), Box<dyn st
         retry_jitter: Duration::ZERO,
         requests_per_second: 0,
     })?;
+    let low_confidence_metadata = MetadataReidentifyService::with_selection(
+        database.clone(),
+        tmdb.clone(),
+        Some(MetadataSelectionService::new(
+            database.clone(),
+            ImageWriteService::new(database.clone())?,
+        )),
+    );
     let auth = WebAuthService::new(database.clone())?;
     let emby_auth = EmbyAuthService::new(database.clone())?;
     let app = app_with_state(
@@ -279,6 +288,31 @@ async fn admin_can_start_and_poll_metadata_reidentify() -> Result<(), Box<dyn st
         tokio::time::sleep(Duration::from_millis(25)).await;
     }
     assert_eq!(item_refresh_job["job"]["status"], "COMPLETED");
+
+    sqlx::query(
+        "UPDATE media_items SET title = 'Unrelated Local Title', sort_title = 'unrelated local title'
+         WHERE id = ?",
+    )
+    .bind(&item_id)
+    .execute(database.pool())
+    .await?;
+    sqlx::query("DELETE FROM metadata_candidates WHERE item_id = ?")
+        .bind(&item_id)
+        .execute(database.pool())
+        .await?;
+    let low_confidence_job = low_confidence_metadata
+        .create_item_refresh_job(&item_id, MetadataRefreshMode::FullRefresh)
+        .await?;
+    low_confidence_metadata.run(&low_confidence_job.id).await;
+    let low_confidence_job = low_confidence_metadata
+        .get_job(&low_confidence_job.id)
+        .await?;
+    assert_eq!(low_confidence_job.status, "COMPLETED");
+    assert_eq!(low_confidence_job.items[0].status, "COMPLETED");
+    assert_eq!(
+        low_confidence_job.items[0].error.as_deref(),
+        Some("LOW_CONFIDENCE")
+    );
 
     sqlx::query("UPDATE media_items SET title = '', sort_title = '' WHERE id = ?")
         .bind(&item_id)

--- a/web/src/features/admin/AdminOperationsPage.tsx
+++ b/web/src/features/admin/AdminOperationsPage.tsx
@@ -93,7 +93,12 @@ const ERROR_LABELS: Record<string, string> = {
   CANDIDATE_ERROR: "候选搜索失败",
   LOW_CONFIDENCE: "匹配置信度不足，已转为待确认",
   METADATA_WRITE_FAILED: "元数据写回失败",
+  METADATA_NFO_WRITE_FAILED: "NFO 写回失败",
+  METADATA_IMAGE_WRITE_FAILED: "图片下载或写回失败",
+  METADATA_PEOPLE_WRITE_FAILED: "演员信息写回失败",
+  METADATA_STORAGE_FAILED: "元数据数据库写入失败",
   METADATA_WRITE_UNAVAILABLE: "元数据写回服务不可用",
+  WORKER_FAILED: "任务工作线程异常退出",
   STORAGE_ERROR: "数据库处理失败",
 };
 


### PR DESCRIPTION
## Summary

- treat an empty TMDb search response as a valid no-result outcome instead of a provider failure
- complete low-confidence refresh items with a `LOW_CONFIDENCE` review marker so they do not fail the whole batch
- distinguish NFO, image, people, and metadata-storage write failures in job records and the admin UI
- log worker termination and reconcile items left in `RUNNING` so job progress always reaches its terminal count

## Root cause

Large metadata refreshes exposed three status-model problems: TMDb no-result responses became candidate errors, expected low-confidence matches counted as hard failures, and worker/database completion errors were discarded. The last case left groups of items permanently in `RUNNING`.

## Tests

- `cargo test --locked --test reidentify admin_can_start_and_poll_metadata_reidentify`
- `cargo test --locked --lib metadata_jobs_reconcile_items_left_running_by_workers`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo build --locked`
- `pnpm --dir web exec vitest run` (146 tests)
- `pnpm --dir web build`

The complete Rust suite was also exercised in the project’s Rust container. New tests and all 59 library tests pass; two unrelated environment-sensitive integration assertions (container detection and library plugin availability) prevent a clean all-targets result in that container. The Node static checks pass 42/43 on Windows; the remaining check constructs `C:\\C:\\...` and fails before reading source files.
