### PR TITLE
fix(web): prevent metadata dialog overflow on mobile

### DIFF
--- a/web/src/features/media/MediaIdentifier.css
+++ b/web/src/features/media/MediaIdentifier.css
@@ -1,14 +1,15 @@
-.lux-identifier-editor { width: min(820px, 100%); }
-.lux-identifier-search { display: grid; grid-template-columns: minmax(0, 1fr) 150px auto; align-items: end; gap: 12px; padding: 20px 26px; border-bottom: 1px solid var(--lux-line-soft); }
-.lux-identifier-search label { display: grid; gap: 7px; color: var(--lux-muted); font-size: .76rem; }
-.lux-identifier-search input { min-height: 42px; padding: 0 11px; border: 1px solid var(--lux-line-soft); border-radius: 8px; outline: 0; color: var(--lux-text); background: rgba(255,255,255,.05); }
+.lux-identifier-editor { min-width: 0; width: min(820px, 100%); }
+.lux-identifier-search { display: grid; grid-template-columns: minmax(0, 1fr) 150px auto; align-items: end; gap: 12px; min-width: 0; width: 100%; padding: 20px 26px; overflow-x: hidden; border-bottom: 1px solid var(--lux-line-soft); }
+.lux-identifier-search label { display: grid; gap: 7px; min-width: 0; color: var(--lux-muted); font-size: .76rem; }
+.lux-identifier-search input { min-width: 0; width: 100%; min-height: 42px; padding: 0 11px; border: 1px solid var(--lux-line-soft); border-radius: 8px; outline: 0; color: var(--lux-text); background: rgba(255,255,255,.05); }
 .lux-identifier-search input:focus { border-color: color-mix(in srgb, var(--lux-accent) 58%, var(--lux-line)); box-shadow: 0 0 0 3px color-mix(in srgb, var(--lux-accent) 14%, transparent); }
-.lux-identifier-results { max-height: min(590px, calc(100vh - 250px)); overflow-y: auto; padding: 20px 26px 26px; }
+.lux-identifier-results { min-width: 0; width: 100%; max-height: min(590px, calc(100vh - 250px)); max-height: min(590px, calc(100dvh - 250px)); overflow-x: hidden; overflow-y: auto; padding: 20px 26px 26px; }
 .lux-identifier-results-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
 .lux-identifier-results-heading > span:last-child { color: var(--lux-subtle); font-size: .72rem; }
-.lux-identifier-list { display: grid; gap: 11px; }
-.lux-identifier-card { padding: 16px; border: 1px solid var(--lux-line-soft); border-radius: 11px; background: rgba(255,255,255,.025); }
+.lux-identifier-list { display: grid; gap: 11px; min-width: 0; }
+.lux-identifier-card { min-width: 0; padding: 16px; border: 1px solid var(--lux-line-soft); border-radius: 11px; background: rgba(255,255,255,.025); }
 .lux-identifier-card-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; }
+.lux-identifier-card-heading > div { min-width: 0; }
 .lux-identifier-card-heading strong { display: block; color: var(--lux-text); font-size: .92rem; }
 .lux-identifier-card-heading small, .lux-identifier-card p, .lux-identifier-no-diff { display: block; margin-top: 5px; color: var(--lux-muted); font-size: .74rem; line-height: 1.5; }
 .lux-identifier-card p { margin-bottom: 0; }
@@ -20,7 +21,8 @@
 .lux-identifier-actions .lux-button { min-height: 36px; padding: 0 11px; font-size: .72rem; }
 
 @media (max-width: 560px) {
-  .lux-identifier-search { grid-template-columns: 1fr; }
-  .lux-identifier-search .lux-button { justify-self: start; }
-  .lux-identifier-results { padding-right: 17px; padding-left: 17px; }
+  .lux-identifier-search { grid-template-columns: minmax(0, 1fr); gap: 14px; padding: 16px; }
+  .lux-identifier-search .lux-button { justify-self: stretch; min-height: 44px; }
+  .lux-identifier-results { max-height: calc(100vh - 330px); max-height: calc(100dvh - 330px); padding: 16px; }
+  .lux-identifier-actions .lux-button { min-height: 44px; }
 }

--- a/web/src/react.css
+++ b/web/src/react.css
@@ -1223,6 +1223,23 @@ button:disabled { cursor: not-allowed; opacity: 0.55; }
   .lux-library-management-toolbar > div { justify-content: center; flex-wrap: wrap; }
   .lux-admin-library-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
   .lux-admin-library-overflow { opacity: 1; transform: none; }
+  .lux-library-action-menu {
+    position: fixed;
+    z-index: 50;
+    top: auto;
+    right: 16px;
+    bottom: calc(16px + env(safe-area-inset-bottom));
+    width: min(320px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px - env(safe-area-inset-bottom));
+    max-height: calc(100dvh - 32px - env(safe-area-inset-bottom));
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+    -webkit-overflow-scrolling: touch;
+  }
+  .lux-library-action-menu-heading { position: sticky; z-index: 1; top: 0; background: rgba(30,30,35,.98); backdrop-filter: blur(18px); }
+  .lux-library-action-menu button { min-height: 44px; }
   .lux-library-dialog-header, .lux-library-dialog-scroll { padding-right: 16px; padding-left: 16px; }
   .lux-library-dialog-form { padding-right: 16px; padding-left: 16px; }
   .lux-library-strategy-heading { align-items: flex-start; flex-direction: column; }

--- a/web/src/react.css
+++ b/web/src/react.css
@@ -178,7 +178,7 @@ button:disabled { cursor: not-allowed; opacity: 0.55; }
 .lux-media-action svg { flex: 0 0 auto; color: rgba(255,255,255,.78); }
 
 .lux-media-editor-backdrop { position: fixed; z-index: 80; inset: 0; display: grid; place-items: center; padding: 24px; overflow-y: auto; background: rgba(0,0,0,.72); backdrop-filter: blur(8px); }
-.lux-media-editor { width: min(760px, 100%); max-height: min(820px, calc(100vh - 48px)); overflow: hidden; border: 1px solid var(--lux-line); border-radius: 16px; color: var(--lux-text); background: rgba(20,20,24,.98); box-shadow: 0 28px 80px rgba(0,0,0,.58); }
+.lux-media-editor { min-width: 0; width: min(760px, 100%); max-height: min(820px, calc(100vh - 48px)); max-height: min(820px, calc(100dvh - 48px)); overflow: hidden; border: 1px solid var(--lux-line); border-radius: 16px; color: var(--lux-text); background: rgba(20,20,24,.98); box-shadow: 0 28px 80px rgba(0,0,0,.58); }
 .lux-media-editor-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; padding: var(--lux-dialog-header-padding); border-bottom: 1px solid var(--lux-line-soft); }
 .lux-media-editor-header h2 { margin: 8px 0 5px; color: #fff; font-size: 1.24rem; letter-spacing: -.035em; }
 .lux-media-editor-header p { margin: 0; overflow: hidden; color: var(--lux-muted); font-size: .78rem; text-overflow: ellipsis; white-space: nowrap; }
@@ -909,6 +909,13 @@ button:disabled { cursor: not-allowed; opacity: 0.55; }
 
 @media (max-width: 560px) {
   .lux-header { padding: 14px 15px; }
+.lux-media-editor-backdrop { place-items: center; padding: 12px; }
+.lux-media-editor { width: calc(100vw - 24px); width: calc(100dvw - 24px); max-height: calc(100vh - 24px); max-height: calc(100dvh - 24px); }
+.lux-media-editor-header { min-width: 0; gap: 12px; padding: 16px; }
+.lux-media-editor-header > div { min-width: 0; }
+.lux-media-editor-header h2 { margin-top: 4px; }
+.lux-media-editor-header p { white-space: normal; text-overflow: clip; overflow-wrap: anywhere; text-wrap: pretty; }
+.lux-media-editor-close { width: 44px; height: 44px; }
 .lux-back-button { display: none; }
   .lux-grid-button { display: none; }
   .lux-icon-button, .lux-user-button { min-width: 46px; height: 46px; }

--- a/web/tests/library-action-menu-responsive.test.mjs
+++ b/web/tests/library-action-menu-responsive.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const stylesheet = readFileSync(new URL("../src/react.css", import.meta.url), "utf8");
+const mobileRules = stylesheet.match(/@media \(max-width: 720px\) \{([\s\S]*?)\n\}/)?.[1] ?? "";
+const menuRule = mobileRules.match(/\.lux-library-action-menu\s*\{([^}]*)\}/)?.[1] ?? "";
+
+test("mobile library action menu remains inside the dynamic viewport", () => {
+  assert.match(menuRule, /position:\s*fixed/);
+  assert.match(menuRule, /bottom:\s*calc\(16px \+ env\(safe-area-inset-bottom\)\)/);
+  assert.match(menuRule, /max-height:\s*calc\(100dvh - 32px - env\(safe-area-inset-bottom\)\)/);
+  assert.match(menuRule, /overflow-y:\s*auto/);
+  assert.match(menuRule, /overscroll-behavior:\s*contain/);
+});
+
+test("mobile library action menu keeps touch targets at least 44 pixels tall", () => {
+  assert.match(mobileRules, /\.lux-library-action-menu button\s*\{[^}]*min-height:\s*44px/);
+});

--- a/web/tests/media-identifier-responsive.test.mjs
+++ b/web/tests/media-identifier-responsive.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const identifierStyles = readFileSync(new URL("../src/features/media/MediaIdentifier.css", import.meta.url), "utf8");
+const globalStyles = readFileSync(new URL("../src/react.css", import.meta.url), "utf8");
+
+test("metadata identifier children cannot widen the mobile dialog", () => {
+  assert.match(identifierStyles, /\.lux-identifier-search\s*\{[^}]*min-width:\s*0[^}]*width:\s*100%[^}]*overflow-x:\s*hidden/s);
+  assert.match(identifierStyles, /\.lux-identifier-search input\s*\{[^}]*min-width:\s*0[^}]*width:\s*100%/s);
+  assert.match(identifierStyles, /\.lux-identifier-results\s*\{[^}]*min-width:\s*0[^}]*width:\s*100%[^}]*overflow-x:\s*hidden/s);
+});
+
+test("mobile media dialogs use a viewport-bound width and touch-sized controls", () => {
+  const mobileRules = globalStyles.slice(globalStyles.indexOf("@media (max-width: 560px)"));
+  assert.match(mobileRules, /\.lux-media-editor\s*\{[^}]*width:\s*calc\(100dvw - 24px\)/s);
+  assert.match(mobileRules, /\.lux-media-editor-close\s*\{[^}]*width:\s*44px;\s*height:\s*44px/s);
+  assert.match(identifierStyles, /@media \(max-width: 560px\)[\s\S]*\.lux-identifier-search\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\)/);
+});


### PR DESCRIPTION
## Summary

- bind mobile media dialogs to the dynamic viewport safe width and height
- allow metadata identifier grid children, inputs, cards, and results to shrink without horizontal clipping
- improve mobile header wrapping and keep primary dialog controls at a 44px touch target
- add responsive CSS regression coverage

## Root cause

The metadata identifier form retained intrinsic grid sizing on narrow Android viewports. Combined with the dialog's clipped overflow, form and result content could become wider than the visible dialog and be cut off along the left edge.

## Verification

- `pnpm --dir web test` — 52 Node tests and 157 Vitest tests passed
- `pnpm --dir web build` — passed
- `git diff --check` — passed
- Chromium 393x852 layout check — no page, dialog, form, input, or results horizontal overflow
- deployed test image on an x86_64 NAS — container healthy and fixed CSS served successfully