### PR TITLE
fix(api): accept valid media strategy settings

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8348,6 +8348,18 @@ fn valid_strategy_code(value: &str, max_length: usize) -> bool {
             .all(|character| character.is_ascii_alphanumeric() || character == '-')
 }
 
+fn valid_optional_strategy_code(value: &str, max_length: usize) -> bool {
+    value.is_empty() || valid_strategy_code(value, max_length)
+}
+
+fn valid_plugin_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.chars().count() <= 64
+        && value
+            .split('.')
+            .all(|segment| valid_strategy_code(segment, 32))
+}
+
 fn normalize_server_name(value: &str) -> Option<String> {
     let value = value.trim();
     if value.is_empty() || value.chars().count() > 80 || value.chars().any(char::is_control) {
@@ -8358,7 +8370,7 @@ fn normalize_server_name(value: &str) -> Option<String> {
 
 fn validate_media_strategy(settings: &MediaStrategySettings) -> bool {
     valid_strategy_code(&settings.metadata_language, 32)
-        && valid_strategy_code(&settings.image_language, 32)
+        && valid_optional_strategy_code(&settings.image_language, 32)
         && valid_strategy_code(&settings.region, 16)
         && matches!(
             settings.apply_scope.as_str(),
@@ -8371,7 +8383,7 @@ fn validate_media_strategy(settings: &MediaStrategySettings) -> bool {
         && settings
             .scraper_id
             .as_deref()
-            .map(|value| valid_strategy_code(value, 64))
+            .map(valid_plugin_id)
             .unwrap_or(true)
         && (0..=20).contains(&settings.images.max_backdrop_count)
         && (0..=8192).contains(&settings.images.min_download_width)
@@ -8433,7 +8445,13 @@ async fn admin_update_settings(
         || minimum_ticks < 0
         || !validate_media_strategy(&media_strategy)
     {
-        return StatusCode::BAD_REQUEST.into_response();
+        return api_error(
+            &headers,
+            StatusCode::BAD_REQUEST,
+            lux::ApiErrorCode::InvalidRequest,
+            "全局媒体策略无效",
+        )
+        .into_response();
     }
     if let Some(scraper_id) = media_strategy.scraper_id.as_deref() {
         if let Err(response) = validate_scraper_selection(&headers, &state, Some(scraper_id)).await
@@ -13987,13 +14005,14 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::{
-        CatalogSort, MetadataCandidateFailureKind, build_cookie, catalog_filter_from_emby,
-        emby_media_source_json, emby_media_source_json_with_resolver, emby_media_stream_item_id,
-        emby_playback_info_item_id, is_catalog_aggregation_path, is_emby_legacy_strm_path,
-        is_emby_media_stream_segment, is_emby_playback_callback_path, is_emby_subtitle_path,
-        is_emby_video_path, is_registered_emby_video_path, lux_catalog_source_json,
-        metadata_candidate_failure_kind, playback_client_label, playback_identifier_prefix,
-        record_activity_event, safe_trace_path, secure_cookie_for_request,
+        CatalogSort, MediaStrategySettings, MetadataCandidateFailureKind, build_cookie,
+        catalog_filter_from_emby, emby_media_source_json, emby_media_source_json_with_resolver,
+        emby_media_stream_item_id, emby_playback_info_item_id, is_catalog_aggregation_path,
+        is_emby_legacy_strm_path, is_emby_media_stream_segment, is_emby_playback_callback_path,
+        is_emby_subtitle_path, is_emby_video_path, is_registered_emby_video_path,
+        lux_catalog_source_json, metadata_candidate_failure_kind, playback_client_label,
+        playback_identifier_prefix, record_activity_event, safe_trace_path,
+        secure_cookie_for_request, validate_media_strategy,
     };
     use crate::application::admin_events::{AdminEventHub, AdminEventScope};
     use crate::application::candidates::MetadataCandidateError;
@@ -14007,6 +14026,23 @@ mod tests {
     use axum::http::{HeaderMap, HeaderValue, Uri};
     use serde_json::json;
     use std::time::Duration;
+
+    #[test]
+    fn media_strategy_accepts_frontend_plugin_ids_and_no_image_language_preference() {
+        let mut settings = MediaStrategySettings::default();
+        settings.scraper_id = Some("org.lux.tmdb".to_owned());
+        settings.image_language.clear();
+
+        assert!(validate_media_strategy(&settings));
+    }
+
+    #[test]
+    fn media_strategy_rejects_unsafe_plugin_ids() {
+        let mut settings = MediaStrategySettings::default();
+        settings.scraper_id = Some("../org.lux.tmdb".to_owned());
+
+        assert!(!validate_media_strategy(&settings));
+    }
 
     #[test]
     fn catalog_concurrency_guard_excludes_streaming_paths() {

--- a/tests/resume_favorites.rs
+++ b/tests/resume_favorites.rs
@@ -204,7 +204,7 @@ async fn resume_thresholds_and_favorite_played_endpoints_share_user_state()
 
     let media_strategy = json!({
         "metadataLanguage": "en-US",
-        "imageLanguage": "en",
+        "imageLanguage": "",
         "region": "US",
         "scraperId": null,
         "applyScope": "ALL_CONTENT",
@@ -258,6 +258,56 @@ async fn resume_thresholds_and_favorite_played_endpoints_share_user_state()
     assert_eq!(
         persisted_settings_body["mediaStrategy"]["subtitles"]["hearingImpaired"],
         true
+    );
+    assert_eq!(
+        persisted_settings_body["mediaStrategy"]["imageLanguage"],
+        ""
+    );
+
+    let invalid_media_strategy = client
+        .patch(format!("{base_url}/api/v1/admin/settings"))
+        .header(COOKIE, format!("lux_session={session}; lux_csrf={csrf}"))
+        .header("X-CSRF-Token", &csrf)
+        .json(&json!({
+            "mediaStrategy": {
+                "metadataLanguage": "en-US",
+                "imageLanguage": "en",
+                "region": "US",
+                "scraperId": "../org.lux.tmdb",
+                "applyScope": "ALL_CONTENT",
+                "images": {
+                    "poster": true,
+                    "artwork": false,
+                    "banner": true,
+                    "logo": false,
+                    "thumbnail": false,
+                    "disc": false,
+                    "wallpaper": true,
+                    "maxBackdropCount": 2,
+                    "minDownloadWidth": 1920
+                },
+                "subtitles": {
+                    "autoDownload": true,
+                    "languages": ["en"],
+                    "forcedOnly": false,
+                    "hearingImpaired": true
+                }
+            }
+        }))
+        .send()
+        .await?;
+    assert_eq!(
+        invalid_media_strategy.status(),
+        reqwest::StatusCode::BAD_REQUEST
+    );
+    let invalid_media_strategy_body = invalid_media_strategy.json::<Value>().await?;
+    assert_eq!(
+        invalid_media_strategy_body["error"]["code"],
+        "INVALID_REQUEST"
+    );
+    assert_eq!(
+        invalid_media_strategy_body["error"]["message"],
+        "全局媒体策略无效"
     );
     let relaxed_resume = client
         .get(format!("{base_url}/Users/{admin_id}/Items/Resume"))


### PR DESCRIPTION
## Summary

- accept dotted plugin identifiers such as `org.lux.tmdb` in global and per-library media strategies
- accept the frontend-supported empty image-language value for “no language preference”
- preserve strict validation for unsafe plugin identifiers
- return a structured `INVALID_REQUEST` response with a readable message instead of an empty HTTP 400

## Validation

- `cargo test --locked --test resume_favorites` — 2 passed
- media strategy unit tests — 2 passed
- `cargo fmt --all -- --check`
- `git diff --check`

## Scope

This PR contains only the media-strategy validation bug fix and its tests. It does not include SQLite/PostgreSQL migration code, Compose changes, database migrations, or deployment documentation.
