### PR TITLE
fix(web): 展示运行记录的具体失败原因

### DIFF
--- a/web/src/features/admin/AdminOperationsPage.tsx
+++ b/web/src/features/admin/AdminOperationsPage.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
     AlertTriangle,
     CalendarDays,
+    ChevronDown,
     CheckCircle2,
     ClipboardList,
     Download,
@@ -454,12 +455,38 @@ function Pagination({ page, pageSize, total, onPageChange }: { page: number; pag
 }
 
 function JobRow({ job, libraryNames, onCancel, onRetry, busy }: { job: OperationsJob; libraryNames: ReadonlyMap<string, string>; onCancel: () => void; onRetry: () => void; busy: boolean }) {
+  const [detailsOpen, setDetailsOpen] = useState(false);
   const progress = job.totalCount && job.totalCount > 0 ? Math.min(100, Math.round(((job.processedCount ?? 0) / job.totalCount) * 100)) : null;
   const active = isActiveJob(job.status);
   const retryable = job.status === "FAILED" || job.status === "CANCELLED";
   const error = formatJobError(job.error);
   const libraryLabel = job.libraryId ? libraryNames.get(job.libraryId) ?? job.libraryId : "";
-  return <article className="lux-admin-job-row"><div className={`lux-job-icon${active ? " is-active" : ""}`}>{job.status === "FAILED" ? <AlertTriangle size={17} /> : job.status === "COMPLETED" ? <CheckCircle2 size={17} /> : <FileClock size={17} />}</div><div className="lux-admin-job-main"><div className="lux-admin-job-heading"><strong>{formatJobType(job.jobType)}</strong><span className={`lux-job-status status-${job.status.toLowerCase()}`}>{formatJobStatus(job.status)}</span></div><small>{job.kind === "metadata" ? "元数据任务" : "扫描任务"}{libraryLabel ? ` · 媒体库：${libraryLabel}` : ""} · {job.processedCount ?? 0}{job.totalCount ? ` / ${job.totalCount}` : ""}{error ? ` · ${error}` : ""}</small>{progress !== null ? <div className="lux-job-progress"><span style={{ width: `${progress}%` }} /></div> : null}</div><div className="lux-admin-job-actions">{active ? <button className="lux-icon-button lux-icon-button-small" type="button" aria-label="取消任务" onClick={onCancel} disabled={busy}><StopCircle size={15} /></button> : null}{retryable ? <button className="lux-icon-button lux-icon-button-small" type="button" aria-label="重试任务" onClick={onRetry} disabled={busy}><RotateCcw size={15} /></button> : null}</div></article>;
+  const details = useQuery({
+    queryKey: ["admin", "metadata-jobs", job.id, "details"],
+    queryFn: () => api.adminMetadataReidentifyJob(job.id),
+    enabled: detailsOpen && job.kind === "metadata",
+  });
+  const failedItems = details.data?.job.items?.filter((item) => item.status === "FAILED") ?? [];
+  const jobLabel = formatJobType(job.jobType);
+  return <article className={`lux-admin-job-row${error ? " has-error" : ""}`}>
+    <div className={`lux-job-icon${active ? " is-active" : ""}`}>{job.status === "FAILED" ? <AlertTriangle size={17} /> : job.status === "COMPLETED" ? <CheckCircle2 size={17} /> : <FileClock size={17} />}</div>
+    <div className="lux-admin-job-main">
+      <div className="lux-admin-job-heading"><strong>{jobLabel}</strong><span className={`lux-job-status status-${job.status.toLowerCase()}`}>{formatJobStatus(job.status)}</span></div>
+      <div className="lux-admin-job-meta"><span>{job.kind === "metadata" ? "元数据任务" : "扫描任务"}</span>{libraryLabel ? <span>媒体库：{libraryLabel}</span> : null}<span>进度：{job.processedCount ?? 0}{job.totalCount ? ` / ${job.totalCount}` : ""}</span></div>
+      {error ? <div className="lux-admin-job-error" role="alert"><strong>失败原因</strong><span>{error}</span></div> : null}
+      {detailsOpen && job.kind === "metadata" ? <div className="lux-admin-job-details">
+        {details.isPending ? <p role="status">正在读取失败详情…</p> : null}
+        {details.error ? <p role="alert">详情读取失败：{details.error.message}</p> : null}
+        {details.data ? <><strong>失败条目 {failedItems.length} 个</strong>{failedItems.length ? <ul>{failedItems.map((item) => <li key={item.itemId}><code>{item.itemId}</code><span>{formatJobError(item.error) || "未记录具体原因"}</span></li>)}</ul> : <p>任务未记录逐条失败信息。</p>}</> : null}
+      </div> : null}
+      {progress !== null ? <div className="lux-job-progress"><span style={{ width: `${progress}%` }} /></div> : null}
+    </div>
+    <div className="lux-admin-job-actions">
+      {error && job.kind === "metadata" ? <button className="lux-admin-job-details-toggle" type="button" aria-expanded={detailsOpen} aria-label={`${detailsOpen ? "收起" : "查看"}${jobLabel}失败详情`} onClick={() => setDetailsOpen((open) => !open)}>详情<ChevronDown size={14} /></button> : null}
+      {active ? <button className="lux-icon-button lux-icon-button-small" type="button" aria-label="取消任务" onClick={onCancel} disabled={busy}><StopCircle size={15} /></button> : null}
+      {retryable ? <button className="lux-icon-button lux-icon-button-small" type="button" aria-label="重试任务" onClick={onRetry} disabled={busy}><RotateCcw size={15} /></button> : null}
+    </div>
+  </article>;
 }
 
 function metadataStatusFilter(status: string) {
@@ -512,7 +539,8 @@ function formatJobStatus(status: string) {
 }
 
 function formatJobError(error?: string | null) {
-  return error ? ERROR_LABELS[error] || "任务处理失败" : "";
+  if (!error) return "";
+  return ERROR_LABELS[error] || (/^[A-Z][A-Z0-9_]{1,127}$/.test(error) ? `任务处理失败（${error}）` : "任务处理失败（未提供可识别的错误码）");
 }
 
 function formatAuditEvent(eventType: string) {

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -582,6 +582,12 @@ export class LuxApiClient {
     );
   }
 
+  adminMetadataReidentifyJob(jobId: string) {
+    return this.request<{ job: AdminMetadataReidentifyJob }>(
+      `/api/v1/admin/metadata/reidentify/${encodeURIComponent(jobId)}`,
+    );
+  }
+
   retryMetadataReidentify(jobId: string) {
     return this.request<{ job: AdminMetadataReidentifyJob }>(
       `/api/v1/admin/metadata/reidentify/${encodeURIComponent(jobId)}`,

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -464,6 +464,16 @@ export type AdminMetadataReidentifyJob = {
   updatedAt?: string | number;
   startedAt?: string | number | null;
   finishedAt?: string | number | null;
+  items?: AdminMetadataReidentifyJobItem[];
+};
+
+export type AdminMetadataReidentifyJobItem = {
+  jobId: string;
+  itemId: string;
+  status: "PENDING" | "RUNNING" | "COMPLETED" | "CANCELLED" | "FAILED" | string;
+  candidateCount: number;
+  error?: string | null;
+  updatedAt: string | number;
 };
 
 export type AdminMetadataReidentifyStart = {

--- a/web/src/react.css
+++ b/web/src/react.css
@@ -749,6 +749,19 @@ button:disabled { cursor: not-allowed; opacity: 0.55; }
 .lux-admin-job-heading { display: flex; align-items: center; gap: 9px; }
 .lux-admin-job-heading strong, .lux-admin-log-row strong { overflow: hidden; color: #fff; font-size: .8rem; text-overflow: ellipsis; white-space: nowrap; }
 .lux-admin-job-main > small, .lux-admin-log-row small { display: block; margin-top: 5px; overflow: hidden; color: var(--lux-subtle); font-size: .7rem; text-overflow: ellipsis; white-space: nowrap; }
+.lux-admin-job-meta { display: flex; flex-wrap: wrap; gap: 4px 12px; margin-top: 6px; color: var(--lux-subtle); font-size: .7rem; }
+.lux-admin-job-error { display: grid; gap: 3px; margin-top: 9px; padding: 9px 10px; border-left: 2px solid rgba(220,89,115,.7); border-radius: 0 7px 7px 0; color: #f3aab8; font-size: .72rem; line-height: 1.45; background: rgba(220,89,115,.08); overflow-wrap: anywhere; }
+.lux-admin-job-error strong { color: inherit; font-size: .67rem; }
+.lux-admin-job-details { margin-top: 8px; padding: 10px; border: 1px solid var(--lux-line-soft); border-radius: 8px; color: var(--lux-muted); font-size: .7rem; background: rgba(0,0,0,.12); }
+.lux-admin-job-details > strong { color: var(--lux-text); }
+.lux-admin-job-details p { margin: 0; }
+.lux-admin-job-details ul { display: grid; gap: 7px; margin: 8px 0 0; padding: 0; list-style: none; }
+.lux-admin-job-details li { display: grid; grid-template-columns: minmax(110px, .7fr) minmax(0, 1fr); gap: 10px; }
+.lux-admin-job-details code { overflow: hidden; color: var(--lux-subtle); text-overflow: ellipsis; white-space: nowrap; }
+.lux-admin-job-details-toggle { display: inline-flex; align-items: center; gap: 4px; min-height: 30px; padding: 0 8px; border: 1px solid var(--lux-line-soft); border-radius: 7px; color: var(--lux-muted); font: inherit; font-size: .68rem; background: transparent; cursor: pointer; }
+.lux-admin-job-details-toggle[aria-expanded="true"] svg { transform: rotate(180deg); }
+html[data-lux-theme="light"] .lux-admin-job-error { color: #9f3047; background: rgba(190,47,76,.07); }
+html[data-lux-theme="light"] .lux-admin-job-details { background: rgba(28,28,34,.035); }
 .lux-job-status { padding: 4px 7px; border-radius: 999px; font-size: .62rem; white-space: nowrap; }
 .status-running, .status-pending { color: #b8a4ec; background: rgba(154,126,232,.12); }
 .status-completed { color: #9bdcb3; background: rgba(96,194,132,.1); }
@@ -1004,6 +1017,8 @@ button:disabled { cursor: not-allowed; opacity: 0.55; }
   .lux-admin-diff-list div { grid-template-columns: 80px minmax(0, 1fr); }
   .lux-admin-job-row, .lux-admin-log-row { grid-template-columns: 30px minmax(0, 1fr); }
   .lux-admin-job-actions, .lux-admin-log-row time { grid-column: 2; }
+  .lux-admin-job-actions { flex-wrap: wrap; }
+  .lux-admin-job-details li { grid-template-columns: 1fr; gap: 3px; }
   .lux-admin-pagination { align-items: stretch; flex-direction: column; }
   .lux-admin-pagination > div { display: grid; grid-template-columns: 1fr 1fr; }
   .lux-operations-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }

--- a/web/tests/admin-operations.test.tsx
+++ b/web/tests/admin-operations.test.tsx
@@ -79,6 +79,58 @@ describe("AdminOperationsPage", () => {
     expect(container.textContent).not.toContain("METADATA_REIDENTIFY_STARTED");
   });
 
+  it("shows a readable failure summary and loads per-item metadata failure details on demand", async () => {
+    vi.spyOn(api, "adminJobs").mockResolvedValue({ jobs: [] });
+    vi.spyOn(api, "adminMetadataReidentifyJobs").mockResolvedValue({
+      jobs: [{
+        id: "metadata-job-failed",
+        status: "FAILED",
+        mode: "FILL_MISSING",
+        processedCount: 2,
+        totalCount: 2,
+        error: "METADATA_BATCH_PARTIAL_FAILURE",
+        createdAt: 1_700_000_000,
+        libraryId: "library-1",
+      }],
+    });
+    const getJob = vi.spyOn(api, "adminMetadataReidentifyJob").mockResolvedValue({
+      job: {
+        id: "metadata-job-failed",
+        status: "FAILED",
+        mode: "FILL_MISSING",
+        processedCount: 2,
+        totalCount: 2,
+        error: "METADATA_BATCH_PARTIAL_FAILURE",
+        createdAt: 1_700_000_000,
+        libraryId: "library-1",
+        items: [
+          { jobId: "metadata-job-failed", itemId: "movie-1", status: "FAILED", candidateCount: 1, error: "METADATA_IMAGE_WRITE_FAILED", updatedAt: 1_700_000_001 },
+          { jobId: "metadata-job-failed", itemId: "movie-2", status: "FAILED", candidateCount: 0, error: "TMDB_UNAVAILABLE", updatedAt: 1_700_000_002 },
+        ],
+      },
+    });
+    vi.spyOn(api, "adminLogs").mockResolvedValue({ events: [] });
+    vi.spyOn(api, "adminScheduledTasks").mockResolvedValue({ scheduledTasks: [], total: 0 });
+    renderPage();
+
+    await act(async () => {
+      await vi.waitFor(() => expect(container.textContent).toContain("已注册任务"));
+    });
+    act(() => container.querySelector<HTMLButtonElement>('button[role="tab"]:nth-child(2)')?.click());
+
+    expect(container.textContent).toContain("任务处理失败（METADATA_BATCH_PARTIAL_FAILURE）");
+    expect(container.querySelector(".lux-admin-job-error")?.textContent).toContain("失败原因");
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('button[aria-label="查看元数据仅补全失败详情"]')?.click();
+      await vi.waitFor(() => expect(getJob).toHaveBeenCalledWith("metadata-job-failed"));
+    });
+    expect(container.textContent).toContain("失败条目 2 个");
+    expect(container.textContent).toContain("图片下载或写回失败");
+    expect(container.textContent).toContain("TMDb 服务暂时不可用");
+    expect(container.textContent).toContain("movie-1");
+  });
+
   it("exports a selected UTC log date range from the system log tab", async () => {
     vi.spyOn(api, "adminJobs").mockResolvedValue({ jobs: [] });
     vi.spyOn(api, "adminMetadataReidentifyJobs").mockResolvedValue({ jobs: [] });

--- a/web/tests/api-client.test.ts
+++ b/web/tests/api-client.test.ts
@@ -197,6 +197,36 @@ describe("LuxApiClient", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
+  it("loads metadata job item details only from the existing job detail endpoint", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({
+        job: {
+          id: "metadata-job-1",
+          status: "FAILED",
+          mode: "FILL_MISSING",
+          processedCount: 1,
+          totalCount: 1,
+          createdAt: 1_700_000_000,
+          items: [{
+            jobId: "metadata-job-1",
+            itemId: "movie-1",
+            status: "FAILED",
+            candidateCount: 0,
+            error: "TMDB_UNAVAILABLE",
+            updatedAt: 1_700_000_001,
+          }],
+        },
+      }), { status: 200 }),
+    );
+
+    const result = await new LuxApiClient().adminMetadataReidentifyJob("metadata/job 1");
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "/api/v1/admin/metadata/reidentify/metadata%2Fjob%201",
+    );
+    expect(result.job.items?.[0]?.error).toBe("TMDB_UNAVAILABLE");
+  });
+
   it("locks or unlocks every editable metadata field without changing its values", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const path = String(input);


### PR DESCRIPTION
## 修复内容

- 将运行记录的任务类型、媒体库和进度拆行展示，避免移动端被单行省略号截断
- 失败任务显示明确的失败原因；未知安全错误码不再被统一吞成“任务处理失败”
- 元数据失败任务支持按需展开逐条失败信息和错误原因
- 详情只显示条目 ID 与脱敏错误码，不暴露媒体路径、外部 URL 或凭据

## 验证

- `pnpm --dir web test`（161 tests passed）
- `pnpm --dir web build`
- `git diff --check`

本 PR 仅包含 Web Bug 修复，不包含数据库迁移或 PostgreSQL/Compose 改动。