### PR TITLE
fix: make metadata selection compatible with PostgreSQL

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -7168,7 +7168,7 @@ impl Database {
                  rating = COALESCE(?, rating),
                  rating_source = CASE WHEN ? IS NULL THEN rating_source ELSE ? END,
                  provider_ids_json = ?,
-                 identification_status = CASE WHEN ? THEN 'PENDING' ELSE 'ONLINE_CONFIRMED' END,
+                 identification_status = CASE WHEN ? = 1 THEN 'PENDING' ELSE 'ONLINE_CONFIRMED' END,
                  metadata_fingerprint = ?, metadata_provenance_json = ?, locked_fields_json = ?,
                  thumbnail_fallback_required = ?
              WHERE id = ? AND removed_at IS NULL",
@@ -7201,7 +7201,7 @@ impl Database {
         let selected = self
             .query(
                 "UPDATE metadata_candidates
-             SET status = CASE WHEN ? THEN 'PENDING' ELSE 'SELECTED' END,
+             SET status = CASE WHEN ? = 1 THEN 'PENDING' ELSE 'SELECTED' END,
                  updated_at = unixepoch()
              WHERE id = ? AND item_id = ? AND status = 'PENDING'",
             )
@@ -13946,7 +13946,7 @@ mod tests {
     use super::*;
     use crate::{
         application::{libraries::LibraryService, scanner::LibraryScanner},
-        config::Config,
+        config::{Config, PostgresConnection},
         library::LibraryKind,
     };
 
@@ -14588,5 +14588,121 @@ mod tests {
                 .await
                 .expect("active duplicate should be rejected")
         );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a local PostgreSQL instance"]
+    async fn postgres_metadata_candidate_selection_accepts_integer_boolean_flags() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory");
+        let config = Config {
+            http_addr: "127.0.0.1:8097".parse().expect("test address"),
+            config_dir: temp_dir.path().join("config"),
+        };
+        let connection = DatabaseConfiguration::Postgres(PostgresConnection {
+            host: std::env::var("POSTGRES_TEST_HOST").unwrap_or_else(|_| "127.0.0.1".to_owned()),
+            port: std::env::var("POSTGRES_TEST_PORT")
+                .unwrap_or_else(|_| "55432".to_owned())
+                .parse()
+                .expect("test port"),
+            database: std::env::var("POSTGRES_TEST_DATABASE").unwrap_or_else(|_| "lux".to_owned()),
+            username: std::env::var("POSTGRES_TEST_USER").unwrap_or_else(|_| "lux".to_owned()),
+            password: std::env::var("POSTGRES_TEST_PASSWORD")
+                .unwrap_or_else(|_| "lux-test-password".to_owned()),
+            ssl_mode: "disable".to_owned(),
+        });
+        let database = Database::connect_with_configuration(&config, &connection)
+            .await
+            .expect("PostgreSQL database");
+        let library = LibraryService::new(database.clone())
+            .create_library("Metadata selection", LibraryKind::Movie, false)
+            .await
+            .expect("library");
+        let item_id = Uuid::now_v7().to_string();
+        let candidate_id = Uuid::now_v7().to_string();
+        sqlx::query(
+            "INSERT INTO media_items (
+                id, library_id, item_type, title, sort_title, identification_status,
+                has_available_source
+             ) VALUES (?, ?, 'MOVIE', 'Metadata selection', 'metadata selection',
+                       'LOCAL_CONFIRMED', 1)",
+        )
+        .bind(&item_id)
+        .bind(library.id.to_string())
+        .execute(database.pool())
+        .await
+        .expect("media item");
+        sqlx::query(
+            "INSERT INTO metadata_candidates (
+                id, item_id, provider, provider_id, candidate_json, score, status
+             ) VALUES (?, ?, 'TMDB', '603', '{}', 100, 'PENDING')",
+        )
+        .bind(&candidate_id)
+        .bind(&item_id)
+        .execute(database.pool())
+        .await
+        .expect("metadata candidate");
+
+        let update = |keep_pending| SelectedMetadataUpdate {
+            item_id: &item_id,
+            candidate_id: &candidate_id,
+            title: "Metadata selection",
+            original_title: None,
+            overview: None,
+            production_year: None,
+            premiere_date: None,
+            last_air_date: None,
+            status: None,
+            original_language: None,
+            rating: None,
+            rating_source: None,
+            provider_ids_json: "{}",
+            metadata_fingerprint: &[],
+            provenance_json: "{}",
+            locked_fields_json: "[]",
+            thumbnail_fallback_required: false,
+            keep_pending,
+        };
+
+        assert!(
+            database
+                .select_metadata_candidate(update(true))
+                .await
+                .expect("keep-pending selection")
+        );
+        let identification_status: String =
+            sqlx::query_scalar("SELECT identification_status FROM media_items WHERE id = ?")
+                .bind(&item_id)
+                .fetch_one(database.pool())
+                .await
+                .expect("identification status");
+        assert_eq!(identification_status, "PENDING");
+        let candidate_status: String =
+            sqlx::query_scalar("SELECT status FROM metadata_candidates WHERE id = ?")
+                .bind(&candidate_id)
+                .fetch_one(database.pool())
+                .await
+                .expect("candidate status");
+        assert_eq!(candidate_status, "PENDING");
+
+        assert!(
+            database
+                .select_metadata_candidate(update(false))
+                .await
+                .expect("confirmed selection")
+        );
+        let identification_status: String =
+            sqlx::query_scalar("SELECT identification_status FROM media_items WHERE id = ?")
+                .bind(&item_id)
+                .fetch_one(database.pool())
+                .await
+                .expect("confirmed identification status");
+        assert_eq!(identification_status, "ONLINE_CONFIRMED");
+        let candidate_status: String =
+            sqlx::query_scalar("SELECT status FROM metadata_candidates WHERE id = ?")
+                .bind(&candidate_id)
+                .fetch_one(database.pool())
+                .await
+                .expect("confirmed candidate status");
+        assert_eq!(candidate_status, "SELECTED");
     }
 }


### PR DESCRIPTION
## 问题
PostgreSQL 在保存元数据候选时返回 `argument of CASE/WHEN must be type boolean, not type bigint`，导致页面显示 503 `DATABASE_UNAVAILABLE`。

## 修复
- 将媒体条目识别状态的 `CASE WHEN ?` 改为 `CASE WHEN ? = 1`。
- 将候选状态更新的 `CASE WHEN ?` 改为 `CASE WHEN ? = 1`。
- 增加 PostgreSQL 回归测试，覆盖保留待确认和正式确认两种分支。

## 验证
- `cargo fmt --all -- --check` ✅
- 元数据选择集成测试 12/12 ✅
- `cargo build --locked` ✅
- `cargo test --locked --all-targets`：在既有 `download_api` 测试失败（预期 206，实际 400），与本 PR 无关
- `cargo clippy --locked --all-targets --all-features -- -D warnings`：被现有两个非最简布尔表达式阻断，与本 PR 无关
- PostgreSQL 回归测试已编译；本机未启动 PostgreSQL 测试实例，专项实跑暂不可用
