### PR TITLE
fix: restore series TMDb IDs during unchanged scans

### DIFF
--- a/src/application/scanner.rs
+++ b/src/application/scanner.rs
@@ -268,6 +268,7 @@ impl LibraryScanner {
         let generation = Uuid::now_v7().to_string();
         let roots = self.database.list_library_roots(&library_id_text).await?;
         let mut report = ScanReport::default();
+        let mut refreshed_series = HashSet::new();
         for root in roots {
             let root_path = PathBuf::from(&root.canonical_path);
             let root_is_available = fs::metadata(&root_path)
@@ -290,12 +291,13 @@ impl LibraryScanner {
             while let Some(files) = walker.next_batch(FILE_BATCH_SIZE).await? {
                 for path in files {
                     report.merge(
-                        self.scan_episode_file(
+                        self.scan_episode_file_with_provider_cache(
                             &library_id_text,
                             &root,
                             &root_path,
                             &path,
                             &generation,
+                            Some(&mut refreshed_series),
                         )
                         .await?,
                     );
@@ -327,6 +329,7 @@ impl LibraryScanner {
         let generation = Uuid::now_v7().to_string();
         let roots = self.database.list_library_roots(&library_id_text).await?;
         let mut report = ScanReport::default();
+        let mut refreshed_series = HashSet::new();
         for root in roots {
             let root_path = PathBuf::from(&root.canonical_path);
             let root_is_available = fs::metadata(&root_path)
@@ -361,12 +364,13 @@ impl LibraryScanner {
                             .await?
                         }
                         MixedClassification::Episode => {
-                            self.scan_episode_file(
+                            self.scan_episode_file_with_provider_cache(
                                 &library_id_text,
                                 &root,
                                 &root_path,
                                 &path,
                                 &generation,
+                                Some(&mut refreshed_series),
                             )
                             .await?
                         }
@@ -401,6 +405,26 @@ impl LibraryScanner {
         root_path: &Path,
         path: &Path,
         generation: &str,
+    ) -> Result<ScanReport, ScannerError> {
+        self.scan_episode_file_with_provider_cache(
+            library_id_text,
+            root,
+            root_path,
+            path,
+            generation,
+            None,
+        )
+        .await
+    }
+
+    async fn scan_episode_file_with_provider_cache(
+        &self,
+        library_id_text: &str,
+        root: &StoredLibraryRoot,
+        root_path: &Path,
+        path: &Path,
+        generation: &str,
+        mut refreshed_series: Option<&mut HashSet<String>>,
     ) -> Result<ScanReport, ScannerError> {
         let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
             return Ok(ScanReport::default());
@@ -508,6 +532,25 @@ impl LibraryScanner {
         } else {
             false
         };
+        let should_refresh_series_provider_ids = episode_is_current
+            && !hierarchy.provider_ids.is_empty()
+            && refreshed_series
+                .as_ref()
+                .is_none_or(|series| !series.contains(&series_identity));
+        if should_refresh_series_provider_ids {
+            let series_provider_ids_json = provider_ids_json(&hierarchy.provider_ids);
+            if let Some(series_provider_ids_json) = series_provider_ids_json.as_deref() {
+                self.database
+                    .update_local_provider_ids_for_identity_if_empty(
+                        &series_identity,
+                        series_provider_ids_json,
+                    )
+                    .await?;
+            }
+            if let Some(series) = refreshed_series.as_mut() {
+                series.insert(series_identity.clone());
+            }
+        }
         if episode_is_current && let Some(existing_entry) = existing_entry.as_ref() {
             if is_strm {
                 self.database

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -8877,6 +8877,29 @@ impl Database {
         })
     }
 
+    pub(crate) async fn update_local_provider_ids_for_identity_if_empty(
+        &self,
+        identity_key: &str,
+        provider_ids_json: &str,
+    ) -> Result<(), StorageError> {
+        self.query(
+            "UPDATE media_items
+             SET provider_ids_json = ?
+             WHERE identity_key = ? AND item_type = 'SERIES'
+               AND removed_at IS NULL
+               AND (provider_ids_json IS NULL OR provider_ids_json = '{}')",
+        )
+        .bind(provider_ids_json)
+        .bind(identity_key)
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+        .map_err(|source| StorageError::Sqlx {
+            path: self.path.clone(),
+            source,
+        })
+    }
+
     pub(crate) async fn insert_media_source(
         &self,
         source: NewMediaSource<'_>,

--- a/tests/series_scanner.rs
+++ b/tests/series_scanner.rs
@@ -343,6 +343,49 @@ async fn series_scan_allows_same_title_and_year_in_different_directories()
 }
 
 #[tokio::test]
+async fn series_rescan_restores_tmdb_id_for_unchanged_episode_paths()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let config = Config {
+        http_addr: "127.0.0.1:8097".parse()?,
+        config_dir: temp_dir.path().join("config"),
+    };
+    let root = temp_dir.path().join("Shows");
+    create_file(&root.join("Example Show (2024) {tmdb-12345}/Season 01/Example.Show.S01E01.mkv"))
+        .await?;
+
+    let database = Database::connect(&config).await?;
+    let libraries = LibraryService::new(database.clone());
+    let library = libraries
+        .create_library("Shows", LibraryKind::Series, false)
+        .await?;
+    libraries
+        .add_root(library.id, root.to_str().ok_or("non-utf8 root")?)
+        .await?;
+    let scanner = LibraryScanner::new(database.clone());
+
+    scanner.scan_series_library(library.id).await?;
+    sqlx::query(
+        "UPDATE media_items SET provider_ids_json = NULL
+         WHERE item_type = 'SERIES' AND library_id = ?",
+    )
+    .bind(library.id.to_string())
+    .execute(database.pool())
+    .await?;
+
+    scanner.scan_series_library(library.id).await?;
+    let provider_ids: Option<String> = sqlx::query_scalar(
+        "SELECT provider_ids_json FROM media_items
+         WHERE item_type = 'SERIES' AND library_id = ?",
+    )
+    .bind(library.id.to_string())
+    .fetch_one(database.pool())
+    .await?;
+    assert_eq!(provider_ids.as_deref(), Some(r#"{"Tmdb":"12345"}"#));
+    Ok(())
+}
+
+#[tokio::test]
 async fn series_scan_repairs_legacy_identity_keys_without_creating_duplicates()
 -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;


### PR DESCRIPTION
## 问题
电视剧文件夹或文件名中已经包含 TMDb ID，但文件指纹未变化时，扫描器会提前返回，跳过剧集层级调和，因此 ID 没有登记到数据库。后续元数据任务只能退回标题搜索。

## 修复
- 对未变化的电视剧分集，在提前返回前补写剧集 provider ID。
- 只在剧集记录没有本地 provider ID 时写入，不覆盖已有身份。
- 全量电视剧/混合库扫描中对同一剧集使用一次性缓存，避免每集重复写数据库。
- 增加回归测试，覆盖未变化路径恢复 TMDb ID。

## 验证
- cargo fmt --all -- --check
- cargo build --locked
- 相关媒体匹配、扫描、元数据 API 和 TMDb 测试全部通过

Closes the missing provider-ID registration path for existing TV items.