### PR TITLE
fix: preserve media records across missing-file scans

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,13 +3,13 @@
 .codex
 .env
 .env.*
-config
-media
-data
-logs
-target
-output
-dist
+/config
+/media
+/data
+/logs
+/target
+/output
+/dist
 web/node_modules
 web/dist
 docs
@@ -25,3 +25,4 @@ tools
 *.pem
 *.key
 Lux-开发规格与分步实施计划.md
+**/._*

--- a/docs/LUX-043-PLAN.md
+++ b/docs/LUX-043-PLAN.md
@@ -9,6 +9,8 @@
 - 根路径 `readdir/stat` 失败时只标记该根不可用，不把已有文件批量标记 missing。
 - 已标记不可用的根每次扫描先重新检查目录；恢复后清除 unavailable 状态。
 - 只有本轮成功完整遍历的根才调用 `mark_missing_filesystem_entries`。
+- 成功标记 missing 后，若媒体项已没有任何可用来源，则使用 `removed_at` 软删除该媒体项；空的季和剧集父项也一并软删除。
+- 文件恢复并被重新发现时，扫描器清除 `removed_at`，保留原媒体项的元数据、播放进度和收藏关系。
 - 实时事件不参与删除判断，完整 generation 仍是 missing 的唯一来源。
 
 ## 增量任务
@@ -28,5 +30,5 @@
 
 ## 明确不做
 
-- 不实现 missing 宽限期和 purge 任务。
+- 不执行物理删除或独立 purge 任务；`removed_at` 软删除保留恢复所需的历史记录。
 - 不实现 PollWatcher 回退；实时监听仍由 LUX-042 提供，定时 reconcile 负责兜底。

--- a/migrations-postgres/0026_metadata_job_summaries.sql
+++ b/migrations-postgres/0026_metadata_job_summaries.sql
@@ -1,0 +1,23 @@
+ALTER TABLE metadata_reidentify_jobs
+    ADD COLUMN library_id TEXT REFERENCES libraries(id) ON DELETE SET NULL;
+
+UPDATE metadata_reidentify_jobs jobs
+SET library_id = summaries.library_id
+FROM (
+    SELECT job_items.job_id,
+           CASE
+               WHEN MIN(media_items.library_id) = MAX(media_items.library_id)
+                   THEN MIN(media_items.library_id)
+               ELSE NULL
+           END AS library_id
+    FROM metadata_reidentify_job_items job_items
+    JOIN media_items ON media_items.id = job_items.item_id
+    GROUP BY job_items.job_id
+) summaries
+WHERE summaries.job_id = jobs.id;
+
+CREATE INDEX idx_metadata_reidentify_items_item_job
+    ON metadata_reidentify_job_items(item_id, job_id);
+
+CREATE INDEX idx_metadata_reidentify_jobs_created
+    ON metadata_reidentify_jobs(created_at DESC, id DESC);

--- a/migrations-postgres/0027_metadata_job_scope.sql
+++ b/migrations-postgres/0027_metadata_job_scope.sql
@@ -1,0 +1,10 @@
+ALTER TABLE metadata_reidentify_jobs
+    ADD COLUMN job_scope TEXT NOT NULL DEFAULT 'ITEMS'
+        CHECK (job_scope IN ('ITEMS', 'LIBRARY'));
+
+UPDATE metadata_reidentify_jobs
+SET job_scope = 'LIBRARY'
+WHERE library_id IS NOT NULL AND total_count > 100;
+
+CREATE INDEX idx_metadata_reidentify_jobs_active_scope
+    ON metadata_reidentify_jobs(job_scope, status, created_at DESC, id DESC);

--- a/migrations-postgres/0028_person_index_rebuild_jobs.sql
+++ b/migrations-postgres/0028_person_index_rebuild_jobs.sql
@@ -1,0 +1,18 @@
+CREATE TABLE person_index_rebuild_jobs (
+    library_id TEXT PRIMARY KEY NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+    status TEXT NOT NULL DEFAULT 'QUEUED'
+        CHECK (status IN ('QUEUED', 'RUNNING', 'COMPLETED', 'FAILED', 'CANCELLED')),
+    cursor_id TEXT,
+    processed_count BIGINT NOT NULL DEFAULT 0,
+    total_count BIGINT NOT NULL DEFAULT 0,
+    cancel_requested BIGINT NOT NULL DEFAULT 0 CHECK (cancel_requested IN (0, 1)),
+    schema_version BIGINT NOT NULL DEFAULT 1,
+    error TEXT,
+    created_at BIGINT NOT NULL DEFAULT (unixepoch()),
+    updated_at BIGINT NOT NULL DEFAULT (unixepoch()),
+    started_at BIGINT,
+    finished_at BIGINT
+);
+
+CREATE INDEX idx_person_index_rebuild_jobs_status
+    ON person_index_rebuild_jobs(status, updated_at DESC);

--- a/migrations-postgres/0029_person_index_item_state.sql
+++ b/migrations-postgres/0029_person_index_item_state.sql
@@ -1,6 +1,6 @@
-CREATE TABLE IF NOT EXISTS person_index_item_state (
+CREATE TABLE person_index_item_state (
     item_id TEXT PRIMARY KEY NOT NULL REFERENCES media_items(id) ON DELETE CASCADE,
     source_fingerprint TEXT,
-    relation_schema_version BIGINT NOT NULL DEFAULT 2 CHECK (relation_schema_version > 0),
+    relation_schema_version BIGINT NOT NULL DEFAULT 2,
     updated_at BIGINT NOT NULL DEFAULT (unixepoch())
 );

--- a/migrations-postgres/0030_person_query_indexes.sql
+++ b/migrations-postgres/0030_person_query_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_person_credits_person_item
+    ON person_credits(person_type, provider, person_id, item_id);

--- a/migrations-postgres/0031_media_items_people_index.sql
+++ b/migrations-postgres/0031_media_items_people_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_media_items_people_visible
+    ON media_items(library_id, id);

--- a/migrations-postgres/0078_person_index_rebuild_jobs.sql
+++ b/migrations-postgres/0078_person_index_rebuild_jobs.sql
@@ -1,4 +1,4 @@
-CREATE TABLE person_index_rebuild_jobs (
+CREATE TABLE IF NOT EXISTS person_index_rebuild_jobs (
     library_id TEXT PRIMARY KEY NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
     status TEXT NOT NULL DEFAULT 'QUEUED'
         CHECK (status IN ('QUEUED', 'RUNNING', 'COMPLETED', 'CANCELLED', 'FAILED')),
@@ -15,5 +15,8 @@ CREATE TABLE person_index_rebuild_jobs (
     finished_at BIGINT
 );
 
-CREATE INDEX idx_person_index_rebuild_jobs_status
+ALTER TABLE person_index_rebuild_jobs
+    ADD COLUMN IF NOT EXISTS run_token TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_person_index_rebuild_jobs_status_v2
     ON person_index_rebuild_jobs(status, updated_at DESC, library_id);

--- a/migrations-postgres/0080_person_index_query_indexes.sql
+++ b/migrations-postgres/0080_person_index_query_indexes.sql
@@ -1,6 +1,6 @@
-CREATE INDEX idx_person_credits_person_item
+CREATE INDEX IF NOT EXISTS idx_person_credits_person_item
     ON person_credits(person_type, provider, person_id, item_id);
 
-CREATE INDEX idx_media_items_people_visible
+CREATE INDEX IF NOT EXISTS idx_media_items_people_visible_v2
     ON media_items(library_id, id)
     WHERE removed_at IS NULL;

--- a/migrations-postgres/0082_metadata_job_scope.sql
+++ b/migrations-postgres/0082_metadata_job_scope.sql
@@ -1,8 +1,8 @@
 ALTER TABLE metadata_reidentify_jobs
-    ADD COLUMN library_id TEXT REFERENCES libraries(id) ON DELETE SET NULL;
+    ADD COLUMN IF NOT EXISTS library_id TEXT REFERENCES libraries(id) ON DELETE SET NULL;
 
 ALTER TABLE metadata_reidentify_jobs
-    ADD COLUMN job_scope TEXT NOT NULL DEFAULT 'ITEMS'
+    ADD COLUMN IF NOT EXISTS job_scope TEXT NOT NULL DEFAULT 'ITEMS'
         CHECK (job_scope IN ('ITEMS', 'LIBRARY'));
 
 UPDATE metadata_reidentify_jobs AS jobs
@@ -15,7 +15,7 @@ SET library_id = (
     HAVING COUNT(DISTINCT media_items.library_id) = 1
 );
 
-CREATE INDEX idx_metadata_reidentify_items_item_job
+CREATE INDEX IF NOT EXISTS idx_metadata_reidentify_items_item_job
     ON metadata_reidentify_job_items(item_id, job_id);
 
 CREATE INDEX idx_metadata_reidentify_jobs_scope_status

--- a/src/application/plugins.rs
+++ b/src/application/plugins.rs
@@ -1680,9 +1680,9 @@ impl PluginService {
         // fresh catalog. This matters for updates: a discovery failure must leave
         // the old package available for the next attempt.
         let catalog = PluginCatalog::discover(&plugin_dir);
-        if !catalog
+        if catalog
             .get(&entry.id)
-            .is_some_and(|plugin| plugin.manifest.version == entry.version)
+            .is_none_or(|plugin| plugin.manifest.version != entry.version)
         {
             let _ = fs::remove_file(&destination).await;
             let _ = fs::remove_dir_all(&validation_dir).await;

--- a/src/application/scanner.rs
+++ b/src/application/scanner.rs
@@ -884,6 +884,7 @@ impl LibraryScanner {
             .find_media_item_by_identity(item.identity_key)
             .await?
         {
+            self.database.restore_media_item(&existing.id).await?;
             self.database
                 .update_unconfirmed_hierarchy_item(
                     &existing.id,
@@ -906,6 +907,7 @@ impl LibraryScanner {
                 .adopt_media_item_identity(&existing.id, item.identity_key)
                 .await?
         {
+            self.database.restore_media_item(&existing.id).await?;
             self.database
                 .update_unconfirmed_hierarchy_item(
                     &existing.id,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -7541,7 +7541,9 @@ impl Database {
         .map_err(|source| StorageError::Sqlx {
             path: self.path.clone(),
             source,
-        })
+        })?;
+        self.restore_media_items_for_filesystem_entry(entry.entry_id)
+            .await
     }
 
     pub(crate) async fn update_filesystem_entry_inode(
@@ -7633,6 +7635,45 @@ impl Database {
                     path: self.path.clone(),
                     source,
                 })?;
+            let restore_query = format!(
+                "UPDATE media_items
+                 SET removed_at = NULL
+                 WHERE id IN (
+                     SELECT item_id FROM media_sources
+                     WHERE filesystem_entry_id IN ({placeholders})
+                     UNION
+                     SELECT parent_id
+                     FROM media_items
+                     WHERE id IN (
+                         SELECT item_id FROM media_sources
+                         WHERE filesystem_entry_id IN ({placeholders})
+                     )
+                     UNION
+                     SELECT series_id
+                     FROM media_items
+                     WHERE id IN (
+                         SELECT item_id FROM media_sources
+                         WHERE filesystem_entry_id IN ({placeholders})
+                     )
+                 )"
+            );
+            let mut restore_statement = self.query(sqlx::AssertSqlSafe(restore_query));
+            for entry_id in chunk {
+                restore_statement = restore_statement.bind(entry_id);
+            }
+            for entry_id in chunk {
+                restore_statement = restore_statement.bind(entry_id);
+            }
+            for entry_id in chunk {
+                restore_statement = restore_statement.bind(entry_id);
+            }
+            restore_statement
+                .execute(&mut *transaction)
+                .await
+                .map_err(|source| StorageError::Sqlx {
+                    path: self.path.clone(),
+                    source,
+                })?;
         }
         transaction
             .commit()
@@ -7668,7 +7709,8 @@ impl Database {
         .map_err(|source| StorageError::Sqlx {
             path: self.path.clone(),
             source,
-        })
+        })?;
+        self.restore_media_items_for_filesystem_entry(id).await
     }
 
     pub(crate) async fn mark_filesystem_entry_seen(
@@ -7689,7 +7731,55 @@ impl Database {
         .map_err(|source| StorageError::Sqlx {
             path: self.path.clone(),
             source,
+        })?;
+        self.restore_media_items_for_filesystem_entry(id).await
+    }
+
+    async fn restore_media_items_for_filesystem_entry(
+        &self,
+        filesystem_entry_id: &str,
+    ) -> Result<(), StorageError> {
+        self.query(
+            "UPDATE media_items
+             SET removed_at = NULL
+             WHERE id IN (
+                 SELECT item_id FROM media_sources WHERE filesystem_entry_id = ?
+                 UNION
+                 SELECT parent_id
+                 FROM media_items
+                 WHERE id IN (
+                     SELECT item_id FROM media_sources WHERE filesystem_entry_id = ?
+                 )
+                 UNION
+                 SELECT series_id
+                 FROM media_items
+                 WHERE id IN (
+                     SELECT item_id FROM media_sources WHERE filesystem_entry_id = ?
+                 )
+             )",
+        )
+        .bind(filesystem_entry_id)
+        .bind(filesystem_entry_id)
+        .bind(filesystem_entry_id)
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+        .map_err(|source| StorageError::Sqlx {
+            path: self.path.clone(),
+            source,
         })
+    }
+
+    pub(crate) async fn restore_media_item(&self, item_id: &str) -> Result<(), StorageError> {
+        self.query("UPDATE media_items SET removed_at = NULL WHERE id = ?")
+            .bind(item_id)
+            .execute(&self.pool)
+            .await
+            .map(|_| ())
+            .map_err(|source| StorageError::Sqlx {
+                path: self.path.clone(),
+                source,
+            })
     }
 
     pub(crate) async fn mark_missing_filesystem_entries(
@@ -7697,20 +7787,95 @@ impl Database {
         library_root_id: &str,
         generation: &str,
     ) -> Result<u64, StorageError> {
-        self.query(
-            "UPDATE filesystem_entries
-             SET is_missing = 1, updated_at = unixepoch()
-             WHERE library_root_id = ? AND last_seen_generation != ? AND is_missing = 0",
-        )
-        .bind(library_root_id)
-        .bind(generation)
-        .execute(&self.pool)
-        .await
-        .map(|result| result.rows_affected())
-        .map_err(|source| StorageError::Sqlx {
-            path: self.path.clone(),
-            source,
-        })
+        let mut transaction = self
+            .pool
+            .begin()
+            .await
+            .map_err(|source| StorageError::Sqlx {
+                path: self.path.clone(),
+                source,
+            })?;
+        let missing_entries = self
+            .query(
+                "UPDATE filesystem_entries
+                 SET is_missing = 1, updated_at = unixepoch()
+                 WHERE library_root_id = ? AND last_seen_generation != ? AND is_missing = 0",
+            )
+            .bind(library_root_id)
+            .bind(generation)
+            .execute(&mut *transaction)
+            .await
+            .map_err(|source| StorageError::Sqlx {
+                path: self.path.clone(),
+                source,
+            })?
+            .rows_affected();
+
+        let library_id = self
+            .query_scalar::<String>("SELECT library_id FROM library_roots WHERE id = ?")
+            .bind(library_root_id)
+            .fetch_optional(&mut *transaction)
+            .await
+            .map_err(|source| StorageError::Sqlx {
+                path: self.path.clone(),
+                source,
+            })?;
+        if let Some(library_id) = library_id {
+            for item_type in ["MOVIE", "EPISODE", "UNRESOLVED", "SEASON", "SERIES"] {
+                let child_predicate = if matches!(item_type, "SEASON" | "SERIES") {
+                    "AND NOT EXISTS (
+                        SELECT 1
+                        FROM media_items child
+                        WHERE child.removed_at IS NULL
+                          AND (child.parent_id = media_items.id OR child.series_id = media_items.id)
+                    )"
+                } else {
+                    ""
+                };
+                let source_predicate = if matches!(item_type, "SEASON" | "SERIES") {
+                    ""
+                } else {
+                    "AND EXISTS (
+                        SELECT 1
+                        FROM media_sources existing_source
+                        WHERE existing_source.item_id = media_items.id
+                    )"
+                };
+                let query = format!(
+                    "UPDATE media_items
+                     SET removed_at = unixepoch()
+                     WHERE library_id = ?
+                       AND item_type = ?
+                       AND removed_at IS NULL
+                       {source_predicate}
+                       AND NOT EXISTS (
+                           SELECT 1
+                           FROM media_sources ms
+                           JOIN filesystem_entries fe ON fe.id = ms.filesystem_entry_id
+                           WHERE ms.item_id = media_items.id
+                             AND fe.is_missing = 0
+                       )
+                       {child_predicate}"
+                );
+                self.query(sqlx::AssertSqlSafe(query))
+                    .bind(&library_id)
+                    .bind(item_type)
+                    .execute(&mut *transaction)
+                    .await
+                    .map_err(|source| StorageError::Sqlx {
+                        path: self.path.clone(),
+                        source,
+                    })?;
+            }
+        }
+        transaction
+            .commit()
+            .await
+            .map_err(|source| StorageError::Sqlx {
+                path: self.path.clone(),
+                source,
+            })?;
+        Ok(missing_entries)
     }
 
     pub(crate) async fn reset_media_probe_for_filesystem_entry(
@@ -8136,10 +8301,11 @@ impl Database {
                 .collect::<Vec<_>>()
                 .join(", ");
             let query = format!(
-                "SELECT id, sort_title, production_year
+                "SELECT id, sort_title, production_year, removed_at
                  FROM media_items
                  WHERE library_id = ? AND item_type = 'MOVIE'
-                   AND removed_at IS NULL AND sort_title IN ({placeholders})"
+                   AND sort_title IN ({placeholders})
+                 ORDER BY CASE WHEN removed_at IS NULL THEN 0 ELSE 1 END, id"
             );
             let mut statement = self.query(sqlx::AssertSqlSafe(query)).bind(library_id);
             for sort_title in chunk {
@@ -8171,7 +8337,9 @@ impl Database {
                             path: self.path.clone(),
                             source,
                         })?;
-                movie_items.insert((sort_title, production_year), id);
+                movie_items
+                    .entry((sort_title, production_year))
+                    .or_insert(id);
             }
         }
         Ok(movie_items)
@@ -8544,7 +8712,7 @@ impl Database {
         for (item_id, parent_id) in &parent_updates {
             if !new_item_ids.contains(item_id) {
                 self.query(
-                    "UPDATE media_items SET parent_id = ?
+                    "UPDATE media_items SET parent_id = ?, removed_at = NULL
                      WHERE id = ? AND item_type = 'MOVIE'",
                 )
                 .bind(parent_id.as_deref())

--- a/tests/scanner.rs
+++ b/tests/scanner.rs
@@ -153,6 +153,14 @@ async fn scanner_discovers_one_movie_and_is_idempotent_after_restart()
     .fetch_one(database.pool())
     .await?;
     assert_eq!(unavailable, 0);
+    let removed_at: Option<i64> = sqlx::query_scalar(
+        "SELECT removed_at FROM media_items WHERE id = (
+             SELECT item_id FROM media_sources LIMIT 1
+         )",
+    )
+    .fetch_one(database.pool())
+    .await?;
+    assert!(removed_at.is_some());
 
     tokio::fs::write(movie_dir.join("Example.Movie.2020.mkv"), b"fixture").await?;
     scanner.scan_movie_library(library.id).await?;
@@ -164,6 +172,14 @@ async fn scanner_discovers_one_movie_and_is_idempotent_after_restart()
     .fetch_one(database.pool())
     .await?;
     assert_eq!(available_after_restore, 1);
+    let restored_removed_at: Option<i64> = sqlx::query_scalar(
+        "SELECT removed_at FROM media_items WHERE id = (
+             SELECT item_id FROM media_sources LIMIT 1
+         )",
+    )
+    .fetch_one(database.pool())
+    .await?;
+    assert!(restored_removed_at.is_none());
 
     let item_count: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM media_items WHERE item_type <> 'FOLDER'")

--- a/tests/series_scanner.rs
+++ b/tests/series_scanner.rs
@@ -126,6 +126,67 @@ async fn series_scan_builds_stable_series_season_episode_hierarchy()
 }
 
 #[tokio::test]
+async fn series_scan_soft_deletes_missing_hierarchy_and_restores_it()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let config = Config {
+        http_addr: "127.0.0.1:8097".parse()?,
+        config_dir: temp_dir.path().join("config"),
+    };
+    let root = temp_dir.path().join("Shows");
+    let episode_path = root.join("Example Show/Season 01/Example.Show.S01E01.mkv");
+    create_file(&episode_path).await?;
+
+    let database = Database::connect(&config).await?;
+    let libraries = LibraryService::new(database.clone());
+    let library = libraries
+        .create_library("Shows", LibraryKind::Series, false)
+        .await?;
+    libraries
+        .add_root(library.id, root.to_str().ok_or("non-utf8 root")?)
+        .await?;
+    let scanner = LibraryScanner::new(database.clone());
+    scanner.scan_series_library(library.id).await?;
+
+    let item_ids: Vec<String> = sqlx::query_scalar(
+        "SELECT id FROM media_items WHERE library_id = ? ORDER BY item_type, id",
+    )
+    .bind(library.id.to_string())
+    .fetch_all(database.pool())
+    .await?;
+    assert_eq!(item_ids.len(), 3);
+
+    tokio::fs::remove_file(&episode_path).await?;
+    scanner.scan_series_library(library.id).await?;
+    let removed_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM media_items
+         WHERE library_id = ? AND removed_at IS NOT NULL",
+    )
+    .bind(library.id.to_string())
+    .fetch_one(database.pool())
+    .await?;
+    assert_eq!(removed_count, 3);
+
+    create_file(&episode_path).await?;
+    scanner.scan_series_library(library.id).await?;
+    let restored_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM media_items
+         WHERE library_id = ? AND removed_at IS NULL",
+    )
+    .bind(library.id.to_string())
+    .fetch_one(database.pool())
+    .await?;
+    assert_eq!(restored_count, 3);
+    let item_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM media_items WHERE library_id = ?")
+            .bind(library.id.to_string())
+            .fetch_one(database.pool())
+            .await?;
+    assert_eq!(item_count, 3);
+    Ok(())
+}
+
+#[tokio::test]
 async fn series_scan_repairs_existing_grouped_hierarchy() -> Result<(), Box<dyn std::error::Error>>
 {
     let temp_dir = tempfile::tempdir()?;

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -97,7 +97,10 @@ async fn admin_can_manage_users_and_last_manager_is_protected()
     assert_eq!(jobs.status(), reqwest::StatusCode::OK);
     let jobs_body = jobs.json::<Value>().await?;
     assert_eq!(jobs_body["jobs"].as_array().map(Vec::len), Some(1));
-    assert!(jobs_body["jobs"][0]["finishedAt"].is_null());
+    assert!(matches!(
+        jobs_body["jobs"][0]["status"].as_str(),
+        Some("PENDING" | "RUNNING" | "COMPLETED")
+    ));
     let job_id = jobs_body["jobs"][0]["id"]
         .as_str()
         .ok_or("missing job id")?;


### PR DESCRIPTION
## 变更
- 全量扫描发现文件消失后，将无可用来源的电影、分集软删除，并按层级处理空季度/剧集。
- 文件重新发现时恢复原媒体记录，保留元数据、播放进度和收藏关系。
- 补充电影与剧集扫描恢复测试。
- 恢复 PostgreSQL 历史迁移文件并使重复迁移兼容，避免已有飞牛数据库启动时报 VersionMissing。
- 修复一个现有 Clippy 告警和异步任务测试的时序假设。

## 验证
- cargo fmt --all -- --check
- cargo build --locked
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets -- --test-threads=1

并行测试中的少数 HTTP/文件监听用例曾出现环境时序超时，相关用例单独及单线程运行均通过。