### PR TITLE
Add Emby user write compatibility routes

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -384,6 +384,7 @@ Lux 当前提供一个版本化的原生 Webhook 合同（`schemaVersion: 1`）�
 - LUX-023：已完成根路径/`/emby` 前缀的 System/Ping 本地协议 shape 测试；`GET/POST /System/Ping` 按 Emby OpenAPI 兼容为无需认证的空 200，并完成 VidHub/SenPlayer 真实登录前置探针。
 - 2026-08-23 Infuse 8.5.5726（macOS arm64）连接探针发现：登录成功后请求 `/DisplayPreferences/usersettings?userId=:userId&client=:client`，此前因路由缺失落入 Web 首页 HTML，导致 JSON 解码失败；现已补齐带认证的 `GET /DisplayPreferences/{displayPreferencesId}`，根路径和 `/emby` 前缀均有自动协议回归。完整 Infuse 媒体库、播放和状态流程仍待部署后复测。
 - LUX-024：已完成 Users/Public、AuthenticateByName、Sessions/Logout 的本地协议 shape 和 token 脱敏测试；VidHub 真实登录通过；SenPlayer 认证响应解析失败的历史缺口已补充更完整的 `User`/`SessionInfo` shape，并补齐认证后 `GET /Users/:userId` 用户详情路由；P0 真实 UI 复测已通过。
+- 已补齐 Emby 用户写接口的基础兼容：`POST /Users/:userId`、`POST /Users/:userId/Policy`、`POST /Users/:userId/Password` 和 `POST/GET /Users/:userId/Images/Primary` 直接复用 Lux 的用户存储与头像存储，避免第三方管理端在改名、改密或同步头像时落到 405。
 - Emby `GET /Items/Counts` 现已支持根路径和 `/emby` 前缀，执行 Emby token/API key 鉴权、用户媒体库 ACL，并支持 `UserId` 与 `IsFavorite` 过滤；`tests/emby_counts.rs` 覆盖协议响应。尚未以 Filmly 或 CapyPlayer 真实 UI 复测，不据此宣称客户端兼容。
 - Emby 与 Lux 媒体库列表的 `SortBy=PremiereDate`/`sortBy=PremiereDate` 在条目没有完整发行日期时回退到 `ProductionYear`，并将两者都缺少的条目稳定放在最后；发行日期新旧两个方向均有服务端回归覆盖。
 - 2026-08-23 AfuseKt `2.9.8.6-fix`（Android）HAR 显示其媒体库首页请求会发送空值 `IsFavorite=`；此前 `/Users/{userId}/Items` 和 `/Items/Latest` 因此返回 400，导致库条目与最新资源不显示。Emby 查询现在将空的可选布尔值按未提供处理，`tests/catalog.rs` 已加入 Items/Latest 回归；修复后的真实客户端复测待部署后进行。该客户端请求的 `/Genres` 仍属于规范明确未实现的端点。

--- a/src/api/emby.rs
+++ b/src/api/emby.rs
@@ -17,6 +17,7 @@ pub(super) fn api_routes() -> Router<AppState> {
         .route("/Persons", get(emby_persons))
         .route("/Persons/{person_id}", get(emby_person))
         .route("/Users/{user_id}", get(emby_user))
+        .route("/Users/{user_id}", post(emby_update_user).put(emby_update_user))
         .route("/Users/{user_id}/Views", get(emby_user_views))
         .route("/Users/{user_id}/Items/Root", get(emby_user_root))
         .route("/Users/{user_id}/Items/Resume", get(emby_user_resume))
@@ -24,6 +25,14 @@ pub(super) fn api_routes() -> Router<AppState> {
         .route("/Users/{user_id}/Items/NextUp", get(emby_user_next_up))
         .route("/Users/{user_id}/Items", get(emby_user_items))
         .route("/Users/{user_id}/Items/{item_id}", get(emby_user_item))
+        .route("/Users/{user_id}/Policy", post(emby_update_user_policy).put(emby_update_user_policy))
+        .route("/Users/{user_id}/Password", post(emby_update_user_password).put(emby_update_user_password))
+        .route(
+            "/Users/{user_id}/Images/Primary",
+            get(emby_user_avatar)
+                .post(emby_update_user_avatar)
+                .put(emby_update_user_avatar),
+        )
         .route(
             "/Persons/{person_id}/Images/{image_type}",
             get(emby_person_image).head(emby_person_image),

--- a/src/api/emby_handlers.rs
+++ b/src/api/emby_handlers.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::domain::ids::UserId;
 
 #[derive(Deserialize, Default)]
 pub(super) struct DanmakuQuery {

--- a/src/api/emby_handlers.rs
+++ b/src/api/emby_handlers.rs
@@ -266,6 +266,206 @@ pub(super) async fn emby_user(
     .into_response()
 }
 
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+pub(super) struct EmbyUserUpdateRequest {
+    #[serde(alias = "Name", alias = "Username", alias = "DisplayName")]
+    display_name: Option<String>,
+    #[serde(alias = "Pw", alias = "NewPw", alias = "NewPassword", alias = "Password")]
+    password: Option<String>,
+    is_disabled: Option<bool>,
+    is_administrator: Option<bool>,
+    enable_remote_control_of_other_users: Option<bool>,
+    enable_remote_access: Option<bool>,
+    enable_content_downloading: Option<bool>,
+    enable_subtitle_management: Option<bool>,
+}
+
+async fn update_emby_user_record(
+    headers: &HeaderMap,
+    state: &AppState,
+    api_key: Option<&str>,
+    user_id: &str,
+    request: EmbyUserUpdateRequest,
+    return_updated_user: bool,
+) -> Response {
+    let acting_user = match require_emby_user(headers, state, api_key).await {
+        Ok(user) => user,
+        Err(status) => return status.into_response(),
+    };
+    if !acting_user.can_manage_server && acting_user.id.to_string() != user_id {
+        return StatusCode::FORBIDDEN.into_response();
+    }
+    let Some(database) = state.database.as_ref() else {
+        return StatusCode::SERVICE_UNAVAILABLE.into_response();
+    };
+    let users = match UserStore::new(database.clone()) {
+        Ok(users) => users,
+        Err(_) => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
+    };
+    let can_manage_server = match (
+        request.enable_remote_control_of_other_users,
+        request.enable_subtitle_management,
+    ) {
+        (None, None) => None,
+        (Some(remote_control), None) => Some(remote_control),
+        (None, Some(subtitle_management)) => Some(subtitle_management),
+        (Some(remote_control), Some(subtitle_management)) => {
+            Some(remote_control || subtitle_management)
+        }
+    };
+    match users
+        .update_user(
+            user_id,
+            UserUpdate {
+                display_name: request.display_name.as_deref(),
+                password: request.password.as_deref(),
+                is_disabled: request.is_disabled,
+                is_admin: request.is_administrator,
+                can_manage_server,
+                can_remote_access: request.enable_remote_access,
+                can_download: request.enable_content_downloading,
+            },
+        )
+        .await
+    {
+        Ok(Some(user)) => {
+            if !return_updated_user {
+                return StatusCode::NO_CONTENT.into_response();
+            }
+            let server_name = current_emby_server_name(state).await;
+            let ordered_views = emby_ordered_views(state, &user).await;
+            Json(emby_user_json(
+                &user,
+                &state.server_id,
+                &server_name,
+                &ordered_views,
+            ))
+            .into_response()
+        }
+        Ok(None) => StatusCode::NOT_FOUND.into_response(),
+        Err(UserStoreError::LastManager) => StatusCode::CONFLICT.into_response(),
+        Err(_) => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+    }
+}
+
+pub(super) async fn emby_update_user(
+    headers: HeaderMap,
+    Path(user_id): Path<String>,
+    Query(query): Query<EmbyTokenQuery>,
+    State(state): State<AppState>,
+    Json(request): Json<EmbyUserUpdateRequest>,
+) -> Response {
+    update_emby_user_record(&headers, &state, query.api_key.as_deref(), &user_id, request, true)
+        .await
+}
+
+pub(super) async fn emby_update_user_policy(
+    headers: HeaderMap,
+    Path(user_id): Path<String>,
+    Query(query): Query<EmbyTokenQuery>,
+    State(state): State<AppState>,
+    Json(request): Json<EmbyUserUpdateRequest>,
+) -> Response {
+    update_emby_user_record(
+        &headers,
+        &state,
+        query.api_key.as_deref(),
+        &user_id,
+        request,
+        false,
+    )
+    .await
+}
+
+pub(super) async fn emby_update_user_password(
+    headers: HeaderMap,
+    Path(user_id): Path<String>,
+    Query(query): Query<EmbyTokenQuery>,
+    State(state): State<AppState>,
+    Json(request): Json<EmbyUserUpdateRequest>,
+) -> Response {
+    update_emby_user_record(
+        &headers,
+        &state,
+        query.api_key.as_deref(),
+        &user_id,
+        request,
+        false,
+    )
+    .await
+}
+
+pub(super) async fn emby_user_avatar(
+    headers: HeaderMap,
+    Path(user_id): Path<String>,
+    Query(query): Query<EmbyTokenQuery>,
+    State(state): State<AppState>,
+) -> Response {
+    let user = match require_emby_user(&headers, &state, query.api_key.as_deref()).await {
+        Ok(user) => user,
+        Err(status) => return status.into_response(),
+    };
+    if let Err(status) = ensure_emby_user_scope(&user, &user_id) {
+        return status.into_response();
+    }
+    let Some(avatars) = state.user_avatars.as_ref() else {
+        return StatusCode::SERVICE_UNAVAILABLE.into_response();
+    };
+    let Some(target_user_id) = user_id.parse::<UserId>().ok() else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
+    match avatars.load(target_user_id).await {
+        Ok(Some(avatar)) => match Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, avatar.content_type)
+            .header(CACHE_CONTROL, "private, no-cache")
+            .body(Body::from(avatar.bytes))
+        {
+            Ok(response) => response,
+            Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        },
+        Ok(None) => StatusCode::NOT_FOUND.into_response(),
+        Err(_) => StatusCode::SERVICE_UNAVAILABLE.into_response(),
+    }
+}
+
+pub(super) async fn emby_update_user_avatar(
+    headers: HeaderMap,
+    Path(user_id): Path<String>,
+    Query(query): Query<EmbyTokenQuery>,
+    State(state): State<AppState>,
+    body: Bytes,
+) -> Response {
+    let user = match require_emby_user(&headers, &state, query.api_key.as_deref()).await {
+        Ok(user) => user,
+        Err(status) => return status.into_response(),
+    };
+    if !user.can_manage_server && user.id.to_string() != user_id {
+        return StatusCode::FORBIDDEN.into_response();
+    }
+    let Some(avatars) = state.user_avatars.as_ref() else {
+        return StatusCode::SERVICE_UNAVAILABLE.into_response();
+    };
+    let Some(target_user_id) = user_id.parse::<UserId>().ok() else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
+    let content_type = headers
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    match avatars.store(target_user_id, content_type, &body).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(UserAvatarError::UnsupportedContentType | UserAvatarError::InvalidContent) => {
+            StatusCode::BAD_REQUEST.into_response()
+        }
+        Err(UserAvatarError::TooLarge { .. }) => StatusCode::PAYLOAD_TOO_LARGE.into_response(),
+        Err(UserAvatarError::InvalidPath(_) | UserAvatarError::Io { .. }) => {
+            StatusCode::SERVICE_UNAVAILABLE.into_response()
+        }
+    }
+}
+
 pub(super) async fn emby_ordered_views(state: &AppState, user: &UserRecord) -> Vec<String> {
     let (Some(libraries), Some(access)) = (state.libraries.as_ref(), state.access.as_ref()) else {
         return Vec::new();

--- a/tests/emby_auth.rs
+++ b/tests/emby_auth.rs
@@ -11,8 +11,11 @@ use luxd::{
     storage::Database,
 };
 use reqwest::header::AUTHORIZATION;
+use reqwest::header::CONTENT_TYPE;
+use image::{DynamicImage, ImageFormat};
 use serde_json::json;
 use sha2::{Digest, Sha256};
+use std::io::Cursor;
 use tokio::net::TcpListener;
 
 struct AbortOnDrop<T>(tokio::task::JoinHandle<T>);
@@ -33,7 +36,7 @@ async fn emby_users_requires_server_manager_and_supports_both_prefixes()
     };
     let database = Database::connect(&config).await?;
     let setup = SetupService::new(database.clone())?;
-    let admin = setup
+    let _admin = setup
         .complete("Admin", "Administrator", "correct password")
         .await?;
     let users = UserStore::new(database.clone())?;
@@ -111,6 +114,117 @@ async fn emby_users_requires_server_manager_and_supports_both_prefixes()
 
     let missing_key = client.get(format!("http://{address}/Users")).send().await?;
     assert_eq!(missing_key.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn emby_user_policy_password_and_avatar_updates_round_trip()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let config = Config {
+        http_addr: "127.0.0.1:8097".parse()?,
+        config_dir: temp_dir.path().join("config"),
+    };
+    let database = Database::connect(&config).await?;
+    let setup = SetupService::new(database.clone())?;
+    let _admin = setup
+        .complete("Admin", "Administrator", "correct password")
+        .await?;
+    let users = UserStore::new(database.clone())?;
+    let viewer = users
+        .create_user("Viewer", "Viewer", "viewer password", false)
+        .await?;
+    let app = app_with_state(AppState::ready(
+        config.clone(),
+        database.clone(),
+        setup,
+        WebAuthService::new(database.clone())?,
+        EmbyAuthService::new(database.clone())?,
+    ));
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let _server = AbortOnDrop(tokio::spawn(
+        async move { axum::serve(listener, app).await },
+    ));
+    let client = reqwest::Client::new();
+
+    let admin_login = client
+        .post(format!("http://{address}/Users/AuthenticateByName"))
+        .json(&serde_json::json!({
+            "Username": "ADMIN",
+            "Pw": "correct password"
+        }))
+        .send()
+        .await?;
+    assert_eq!(admin_login.status(), reqwest::StatusCode::OK);
+    let admin_token = admin_login.json::<serde_json::Value>().await?["AccessToken"]
+        .as_str()
+        .ok_or("missing admin token")?
+        .to_owned();
+
+    let policy_update = client
+        .post(format!("http://{address}/emby/Users/{}/Policy", viewer.id))
+        .header(AUTHORIZATION, format!(r#"Emby Client="Infuse", Device="iPhone", DeviceId="device-2", Version="1.0.0", Token="{}""#, admin_token))
+        .json(&serde_json::json!({
+            "EnableRemoteControlOfOtherUsers": true,
+            "EnableRemoteAccess": true,
+            "EnableContentDownloading": true,
+            "EnableSubtitleManagement": true
+        }))
+        .send()
+        .await?;
+    assert_eq!(policy_update.status(), reqwest::StatusCode::NO_CONTENT);
+
+    let user_after_policy = client
+        .get(format!("http://{address}/emby/Users/{}", viewer.id))
+        .query(&[("api_key", admin_token.as_str())])
+        .send()
+        .await?;
+    assert_eq!(user_after_policy.status(), reqwest::StatusCode::OK);
+    let user_after_policy_body: serde_json::Value = user_after_policy.json().await?;
+    assert_eq!(user_after_policy_body["Policy"]["EnableRemoteAccess"], true);
+    assert_eq!(user_after_policy_body["Policy"]["EnableContentDownloading"], true);
+
+    let password_update = client
+        .post(format!("http://{address}/emby/Users/{}/Password", viewer.id))
+        .query(&[("api_key", admin_token.as_str())])
+        .json(&serde_json::json!({
+            "NewPw": "new viewer password"
+        }))
+        .send()
+        .await?;
+    assert_eq!(password_update.status(), reqwest::StatusCode::NO_CONTENT);
+
+    let relogin = client
+        .post(format!("http://{address}/Users/AuthenticateByName"))
+        .json(&serde_json::json!({
+            "Username": "viewer",
+            "Pw": "new viewer password"
+        }))
+        .send()
+        .await?;
+    assert_eq!(relogin.status(), reqwest::StatusCode::OK);
+
+    let mut avatar = Cursor::new(Vec::new());
+    DynamicImage::new_rgba8(1, 1)
+        .write_to(&mut avatar, ImageFormat::Png)?;
+    let avatar_bytes = avatar.into_inner();
+    let avatar_upload = client
+        .post(format!("http://{address}/emby/Users/{}/Images/Primary", viewer.id))
+        .query(&[("api_key", admin_token.as_str())])
+        .header(CONTENT_TYPE, "image/png")
+        .body(avatar_bytes.clone())
+        .send()
+        .await?;
+    assert_eq!(avatar_upload.status(), reqwest::StatusCode::NO_CONTENT);
+
+    let avatar_path = temp_dir
+        .path()
+        .join("config")
+        .join("user-avatars")
+        .join(viewer.id.to_string());
+    assert_eq!(tokio::fs::read(avatar_path).await?, avatar_bytes);
 
     Ok(())
 }


### PR DESCRIPTION
## What\n- Add Emby user write compatibility routes that NE relies on for rename/password/avatar sync.\n- Reuse Lux's existing user store and avatar store instead of returning 405.\n\n## Scope\n- \n- \n- \n- \n\n## Validation\n- Added a focused integration test covering policy, password, and avatar round-trip behavior.\n-  is clean.\n- I could not run  here because this machine does not have Rust tooling installed.