### PR TITLE
fix: preserve original STRM playback URLs for Emby clients

### DIFF
--- a/src/api/playback.rs
+++ b/src/api/playback.rs
@@ -67,7 +67,17 @@ pub(super) async fn emby_playback_info(
                 let has_direct_stream_url = value
                     .get("DirectStreamUrl")
                     .is_some_and(Value::is_string);
-                if has_direct_stream_url
+                if has_direct_stream_url && source.source_kind == "STRM_URL" {
+                    // Keep the original CMS/302 URL so downstream proxies can
+                    // extract the pickcode and filename from the STRM source.
+                    if let Value::Object(object) = &mut value {
+                        object.insert(
+                            "DirectStreamUrl".to_owned(),
+                            json!(source.external_url),
+                        );
+                        object.insert("AddApiKeyToDirectStreamUrl".to_owned(), json!(false));
+                    }
+                } else if has_direct_stream_url
                     && let Some(service) = state.web_playback.as_ref()
                     && let Some(url) = emby_signed_direct_stream_url(service, &item.id, source, &user)
                     && let Value::Object(object) = &mut value


### PR DESCRIPTION
## Problem
For STRM-backed media, Lux rewrites `DirectStreamUrl` to a Lux virtual signed URL. Downstream Emby-compatible proxies such as NextEmby cannot extract the original CMS/302 pickcode from that URL, which can cause playback to resolve to an account-error video.

## Fix
When the source kind is `STRM_URL`, keep the original `external_url` in `DirectStreamUrl` and disable API-key appending. Other source kinds retain the existing signed playback behavior.

## Validation
Verified with a local Lux build, NextEmby, and CMS: `PlaybackInfo` returns 200 and the CMS/302 endpoint returns 302.