### PR TITLE
fix: ignore unavailable movies in NFO identity conflicts

### DIFF
--- a/src/storage/media.rs
+++ b/src/storage/media.rs
@@ -1584,7 +1584,11 @@ impl Database {
                   AND conflicting_item.production_year = ?
                   AND conflicting_item.removed_at IS NULL
                   AND conflicting_item.has_available_source = 1
-                  AND conflicting_item.parent_id IS DISTINCT FROM current_item.parent_id
+                  AND (
+                      current_item.parent_id IS NULL
+                      OR conflicting_item.parent_id IS NULL
+                      OR conflicting_item.parent_id IS DISTINCT FROM current_item.parent_id
+                  )
                  WHERE current_item.id = ?
                    AND current_item.item_type = 'MOVIE'
                    AND current_item.removed_at IS NULL

--- a/src/storage/media.rs
+++ b/src/storage/media.rs
@@ -1584,6 +1584,7 @@ impl Database {
                   AND conflicting_item.production_year = ?
                   AND conflicting_item.removed_at IS NULL
                   AND conflicting_item.has_available_source = 1
+                  AND conflicting_item.parent_id IS DISTINCT FROM current_item.parent_id
                  WHERE current_item.id = ?
                    AND current_item.item_type = 'MOVIE'
                    AND current_item.removed_at IS NULL

--- a/src/storage/media.rs
+++ b/src/storage/media.rs
@@ -1583,6 +1583,7 @@ impl Database {
                   AND conflicting_item.sort_title = ?
                   AND conflicting_item.production_year = ?
                   AND conflicting_item.removed_at IS NULL
+                  AND conflicting_item.has_available_source = 1
                  WHERE current_item.id = ?
                    AND current_item.item_type = 'MOVIE'
                    AND current_item.removed_at IS NULL

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -830,3 +830,43 @@ async fn metadata_enrichment_ignores_conflicts_without_available_sources()
     assert!(current.2.is_some());
     Ok(())
 }
+
+#[tokio::test]
+async fn metadata_enrichment_allows_nfo_variants_in_one_movie_folder()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let config = Config {
+        http_addr: "127.0.0.1:8097".parse()?,
+        config_dir: temp_dir.path().join("config"),
+    };
+    let root = temp_dir.path().join("Movies");
+    let movie_dir = root.join("Variant Movie");
+    tokio::fs::create_dir_all(&movie_dir).await?;
+    for variant in ["有码", "破解"] {
+        tokio::fs::write(movie_dir.join(format!("Movie {variant}.mkv")), b"movie").await?;
+        tokio::fs::write(
+            movie_dir.join(format!("Movie {variant}.nfo")),
+            "<movie><title>Variant Movie</title><year>2024</year></movie>",
+        )
+        .await?;
+    }
+
+    let database = Database::connect(&config).await?;
+    let libraries = LibraryService::new(database.clone());
+    let library = libraries
+        .create_library("Movies", LibraryKind::Movie, false)
+        .await?;
+    libraries
+        .add_root(library.id, root.to_str().ok_or("non-utf8 path")?)
+        .await?;
+    LibraryScanner::new(database.clone())
+        .scan_movie_library(library.id)
+        .await?;
+
+    let report = MetadataEnricher::new(database.clone())
+        .enrich_movie_library(library.id)
+        .await?;
+    assert_eq!(report.nfo_loaded, 2);
+    assert_eq!(report.nfo_failed, 0);
+    Ok(())
+}

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -832,7 +832,7 @@ async fn metadata_enrichment_ignores_conflicts_without_available_sources()
 }
 
 #[tokio::test]
-async fn metadata_enrichment_allows_nfo_variants_in_one_movie_folder()
+async fn metadata_enrichment_allows_same_parent_nfo_identity_variants()
 -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = tempfile::tempdir()?;
     let config = Config {
@@ -842,11 +842,15 @@ async fn metadata_enrichment_allows_nfo_variants_in_one_movie_folder()
     let root = temp_dir.path().join("Movies");
     let movie_dir = root.join("Variant Movie");
     tokio::fs::create_dir_all(&movie_dir).await?;
-    for variant in ["有码", "破解"] {
-        tokio::fs::write(movie_dir.join(format!("Movie {variant}.mkv")), b"movie").await?;
+    for year in [2023, 2024] {
         tokio::fs::write(
-            movie_dir.join(format!("Movie {variant}.nfo")),
-            "<movie><title>Variant Movie</title><year>2024</year></movie>",
+            movie_dir.join(format!("Variant Movie ({year}).mkv")),
+            b"movie",
+        )
+        .await?;
+        tokio::fs::write(
+            movie_dir.join(format!("Variant Movie ({year}).nfo")),
+            "<movie><title>Variant Movie</title><year>2023</year></movie>",
         )
         .await?;
     }
@@ -868,5 +872,53 @@ async fn metadata_enrichment_allows_nfo_variants_in_one_movie_folder()
         .await?;
     assert_eq!(report.nfo_loaded, 2);
     assert_eq!(report.nfo_failed, 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn metadata_enrichment_rejects_conflicting_nfo_for_flat_movie_files()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let config = Config {
+        http_addr: "127.0.0.1:8097".parse()?,
+        config_dir: temp_dir.path().join("config"),
+    };
+    let root = temp_dir.path().join("Movies");
+    tokio::fs::create_dir_all(&root).await?;
+    tokio::fs::write(root.join("Target Movie (1987).mkv"), b"existing movie").await?;
+    tokio::fs::write(
+        root.join("Target Movie (1987).nfo"),
+        "<movie><title>Target Movie</title><year>1987</year></movie>",
+    )
+    .await?;
+    tokio::fs::write(
+        root.join("Different Movie (2018).mkv"),
+        b"conflicting movie",
+    )
+    .await?;
+    tokio::fs::write(
+        root.join("Different Movie (2018).nfo"),
+        "<movie><title>Target Movie</title><year>1987</year></movie>",
+    )
+    .await?;
+
+    let database = Database::connect(&config).await?;
+    let libraries = LibraryService::new(database.clone());
+    let library = libraries
+        .create_library("Movies", LibraryKind::Movie, false)
+        .await?;
+    libraries
+        .add_root(library.id, root.to_str().ok_or("non-utf8 path")?)
+        .await?;
+    LibraryScanner::new(database.clone())
+        .scan_movie_library(library.id)
+        .await?;
+
+    let report = MetadataEnricher::new(database.clone())
+        .enrich_movie_library(library.id)
+        .await?;
+
+    assert_eq!(report.nfo_loaded, 1);
+    assert_eq!(report.nfo_failed, 1);
     Ok(())
 }

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -767,3 +767,66 @@ async fn metadata_enrichment_skips_conflicting_nfo_and_indexes_following_images(
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn metadata_enrichment_ignores_conflicts_without_available_sources()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    let config = Config {
+        http_addr: "127.0.0.1:8097".parse()?,
+        config_dir: temp_dir.path().join("config"),
+    };
+    let root = temp_dir.path().join("Movies");
+    let historical_dir = root.join("Target Movie (1987)");
+    let current_dir = root.join("Renamed Movie (2018)");
+    tokio::fs::create_dir_all(&historical_dir).await?;
+    tokio::fs::create_dir_all(&current_dir).await?;
+    tokio::fs::write(
+        historical_dir.join("Target Movie (1987).mkv"),
+        b"historical",
+    )
+    .await?;
+    tokio::fs::write(current_dir.join("Renamed Movie (2018).mkv"), b"current").await?;
+    tokio::fs::write(
+        current_dir.join("Renamed Movie (2018).nfo"),
+        "<movie><title>Target Movie</title><year>1987</year></movie>",
+    )
+    .await?;
+
+    let database = Database::connect(&config).await?;
+    let libraries = LibraryService::new(database.clone());
+    let library = libraries
+        .create_library("Movies", LibraryKind::Movie, false)
+        .await?;
+    libraries
+        .add_root(library.id, root.to_str().ok_or("non-utf8 path")?)
+        .await?;
+    LibraryScanner::new(database.clone())
+        .scan_movie_library(library.id)
+        .await?;
+    sqlx::query(
+        "UPDATE media_items SET has_available_source = 0
+         WHERE library_id = ? AND production_year = 1987",
+    )
+    .bind(library.id.to_string())
+    .execute(database.pool())
+    .await?;
+
+    let report = MetadataEnricher::new(database.clone())
+        .with_nfo_store(LocalNfoMetadataStore::new(database.clone()))
+        .enrich_movie_library(library.id)
+        .await?;
+
+    assert_eq!(report.nfo_loaded, 1);
+    assert_eq!(report.nfo_failed, 0);
+    let current: (String, i64, Option<String>) = sqlx::query_as(
+        "SELECT title, production_year, nfo_metadata_json
+         FROM media_items WHERE has_available_source = 1",
+    )
+    .fetch_one(database.pool())
+    .await?;
+    assert_eq!(current.0, "Target Movie");
+    assert_eq!(current.1, 1987);
+    assert!(current.2.is_some());
+    Ok(())
+}


### PR DESCRIPTION
## Problem
Local NFO identity conflict detection had two edge cases: stale media rows with no available sources blocked replacement items, while allowing variants in one movie folder accidentally disabled conflicts for flat movie files because both parent IDs are NULL.

## Fix
- Ignore removed or unavailable movie items as conflict candidates.
- Allow different NFO identities only when both movie sources belong to the same non-empty parent folder.
- Keep conflicts for flat files, root-vs-folder files, and different folders.

## Validation
- Added regression coverage for unavailable historical rows, same-folder variants, and conflicting flat movie files.
- `cargo test --locked --test metadata`: 19 passed
- `cargo test --locked --all-targets`: passed; 4 PostgreSQL-specific tests ignored because no local PostgreSQL instance is available
- `cargo build --locked`: passed
- `cargo clippy --locked --all-targets --all-features -- -D warnings`: passed
- `cargo fmt --all -- --check`: passed
- GitHub Docker image checks: amd64 and arm64 passed

This is independent of closed PR #19.